### PR TITLE
correcting API_BASE url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you aren't working on the parser, you may want to just configure the
 application to run against the live API:
 
 ```bash
-$ echo "API_BASE = 'https://fec-eregs.18f.gov/api/'" >> local_settings.py
+$ echo "API_BASE = 'https://fec-eregs.apps.cloud.gov/api/'" >> local_settings.py
 ```
 
 ### Ports


### PR DESCRIPTION
The API_BASE url listed in the readme isn't working. This updates it to the real API, at least until we set up a permanent home for it that isn't in CM's sandbox space.