### PR TITLE
Continuous deployment via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,23 @@ language: python
 sudo: false
 python:
     - "2.7"
-install: 
+install:
     - pip install -r requirements.txt
     - npm install -g grunt-cli bower
 script:
     - python manage.py migrate --fake-initial
     - python manage.py compile_frontend
+
+# This does not handle zero-downtime deployments
+deploy:
+  edge: true
+  provider: cloudfoundry
+  username: fec_deployer
+  password:
+    secure: Ot4dJAfvO5ucce4afyIgkA3nhERLPnPdrtYoNGiXShP+ZiQbS3GLSlD8xtZU/cbTmembCr/zhZWjpqZwLEwYzzYMY0xx2kUC0jzXxHPIXrKTR6Mm9sM5MEkZN063QoJe1xMNaMExNY+9o2VQfH+1GJtM1VU+tJvbhZv5sHqvzwWSkkMjADsWJGJFDz0WdKQTFvnmwLXpo4LNtMjG+WZUidgZYK2qTFXekqXp4gyS37yB645KxFQt4M3I+8vlfcAq1OZzaUH5aB/ZK1MApUxVy81cfYe/UmKAgpJ/lkJwvZzizTjT0oXvhAuY1z3VebsJ0cf6Tf2PDF09NnTm3+0DVqiF2LGLmnfWlvDt9i2Ozx2hMg61hph7mpds44I4uTPlBsLHWG8xeXNDF8OJAbOVKdmQxiIA653n4ssC3OjNBNwCGHU324TdtTQlUL+Kd0VzqrvkZc2o+5zWonG61lzf8AwHXv72KxMGPxUxO/a4DaqP6+2gXIutWxXTWUPZIe6+MeTcWk1xGE/3qO8TARt69wnlYnHP82MrlO3zOw3ZfindYT4DBCTN2az+tEuzB+QrP/4boQUSWn+fvip4STRqzQ/oB6zC1U0DDmu2D8Jqzivb+ZVpgjWICt6lhdiEqO3uowk5VLXzyW0Bb+Pp4diEF/r6bmx1GoavVCMNiEeK/Y0=
+  api: https://api.cloud.gov
+  organization: fec
+  space: dev
+  manifest: manifest.dev.yml
+  on:
+    branch: travis-deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ script:
     - python manage.py migrate --fake-initial
     - python manage.py compile_frontend
 
+# Simple smoke tests
+after_deploy:
+  - curl --silent --fail --head https://fec-eregs-dev.apps.cloud.gov || travis_terminate $?
+  - curl --silent --fail --get https://fec-eregs-dev.apps.cloud.gov/api/regulation/2 > /dev/null || travis_terminate $?
+
 # This does not handle zero-downtime deployments
 deploy:
   edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ deploy:
   space: dev
   manifest: manifest.dev.yml
   on:
-    branch: travis-deploy
+    branch: master

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ changes locally:
 ```bash
 $ python manage.py runserver &    # start the server as a background process
 $ cd path/to/regulations-parser
-$ eregs pipeline 27 479 http://localhost:8000/api   # send the data
+$ eregs pipeline 11 4 http://localhost:8000/api   # send the data
 ```
 
 If you aren't working on the parser, you may want to just configure the

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build
+Status](https://travis-ci.org/18F/fec-eregs.svg?branch=master)](https://travis-ci.org/18F/fec-eregs)
+
 # FEC's eRegs
 [![Code Issues](https://www.quantifiedcode.com/api/v1/project/e2ee92b5c3db486f89d47371c4d89a2f/badge.svg)](https://www.quantifiedcode.com/app/project/e2ee92b5c3db486f89d47371c4d89a2f)
 

--- a/manifest.base.yml
+++ b/manifest.base.yml
@@ -1,5 +1,8 @@
 ---
 command: python manage.py migrate --fake-initial && python manage.py rebuild_index --noinput --remove && python manage.py collectstatic --noinput && waitress-serve --port=$VCAP_APP_PORT fec_eregs.wsgi:application
-
+services:
+  - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
+  - fec-eregs-db
+  - fec-eregs-search-1.7.1
 env:
   DJANGO_SETTINGS_MODULE: fec_eregs.settings.prod

--- a/manifest.dev.yml
+++ b/manifest.dev.yml
@@ -1,0 +1,5 @@
+---
+inherit: manifest.base.yml
+host: fec-eregs-dev
+applications:
+  - name: fec-eregs-dev

--- a/manifest.prod.yml
+++ b/manifest.prod.yml
@@ -1,0 +1,6 @@
+---
+inherit: manifest.base.yml
+host: fec-eregs
+instances: 5
+applications:
+  - name: fec-eregs


### PR DESCRIPTION
Travis will now push to our [dev space](https://fec-eregs-dev.apps.cloud.gov/) on a successful push to master, i.e. whenever a PR is merged and passes any tests (currently there are none).

cc @18F/fec 

## Manifest split

This restructures the manifest file for the `dev` space and the `prod` space, sharing a lot of configuration between them. This was cribbed off of @jmcarp's [work in atf-eregs](https://github.com/18F/atf-eregs/commit/fb8b5e00caa999ae29e8eb0f0c3956579256d3a2).

## Travis's Cloud Foundry deploy provider

For simplicity and to avoid too much copy/paste, I went with Travis' deploy provider. This uses `cf push` under the hood rather than our blue-green script or concourse's autopilot. That means that we're not using zero-downtown deployment, which should be okay for now since we're only using CD for the `dev` space. Comment if you have other suggestions :)

## Smoke tests

These are very light smoke tests that verify the deploy was successful. All they do is check the dev site isn't 500'ing on two very specific URLs. Any rollback is manual, which you'll know to do because there will be a failed build in Travis.