### PR TITLE
Improvements for defined terms

### DIFF
--- a/eregs_extensions/extensions-outline.rst
+++ b/eregs_extensions/extensions-outline.rst
@@ -1,0 +1,105 @@
+eRegulations Parser Extensions Outline
+======================================
+eRegulations has three main projects:
+
++   `regulations-core`_.
++   `regulations-parser`_.
++   `regulations-site`_.
+
+The current approach to developing for a new agency is to have an umbrella project that pulls in `regulations-core`_ and `regulations-site`_ via ``pip install``, and that overrides HTML and CSS elements of `regulations-site`_. An example of that approach is `fec-eregs`_.
+
+This document is concerned with extensions to `regulations-parser`_, which are handled differently.
+
+We assume that the above umbrella approach will be followed, and that an umbrella project of some kind is present and loaded as a set of Python packages via the umbrella project's ``setup.py`` file, and that the developer also has `regulations-parser`_ in their environment and is running it to test changes.
+
+A common setup might look like this::
+
+    cd <project-root>
+    git clone https://github.com/18F/fec-eregs
+    git clone https://github.com/18F/regulations-parser
+    cd fec-eregs
+    pip install -r requirements.txt
+    cd ../regulations-parser
+    pip install -r requirements.txt
+    pip install -r requirements_test.txt
+
+The umbrella project, in this case ``fec-eregs``, has a directory in it named ``eregs_extensions``. This is where agency-specific `regulations-parser`_ code lives.
+
+Namespaces and Modules
+----------------------
+In ``eregs_extensions`` is a directory named ``fec_regparser``. This directory name determines the name of the Python module that will be pulled in by `regulations-parser`_, and must be renamed to something unique to the agency using the extensions. This name must also match the value of the ``fs`` variable in ``eregs_extensions/setup.py``.
+
+`regulations-parser`_ uses `stevedore`_ to handle bringing in modules, determined by their entry points, which we use as namespaces.
+
+The `regulations-parser`_ namespace prefix is ``eregs_ns.parser``, and the parser will only look for extensions whose declared entry points match that.
+
+Currently, the only supported namespaces are ``eregs_ns.parser.preprocessors`` and ``eregs_ns.parser.test_suite``. In future, we hope to have all new agency-specific features use the extensions system, and to add new hooks to `regulations-parser`_ to find extensions in the appropriate code paths.
+
+Creating a New Preprocessor
+---------------------------
+Let's say we have a new agency, MIB, who wish to use eRegulations and to make additions to `regulations-parser`_ to handle their regulations. They fork https://github.com/18F/fec-eregs as ``mib-eregs`` and then follow the setup above.
+
+In ``mib-eregs``, the first thing they would do is rename the ``fec_regparser`` directory to ``mib_regparser``, and alter the ``setup.py`` file so that::
+
+    fs = "fec_regparser"  # The directory name for the package.
+
+becomes::
+
+    fs = "mib_regparser"  # The directory name for the package.
+
+They would remove the existing ATF-specific preprocessors from ``eregs_extensions/mib_regparser/preprocs``, and do the same for the contents of ``eregs_extensions/mib_regparser/tests``.
+
+Any new preprocessor would need to import the base class::
+
+    from regparser.tree.xml_parser.preprocessors import PreProcessorBase
+
+And would likely need ``etree``::
+
+    from lxml import etree
+
+They would also need tests. The tests would need the following import lines::
+
+    from unittest import TestCase
+    from tests.xml_builder import XMLBuilderMixin
+    from mib_regparser.preprocs import <whatever the test is for>
+
+The ``tests.xml_builder`` namespacing is problematic and will probably be changed to ``regparser.tests.xml_builder`` soon.
+
+Note that the test has to reflect the filesystem name ``mib_regparser``—in other words, each test has to change if that name changes.
+
+Current Extension Hooks
+-----------------------
+In `regulations-parser`_, ``settings.py`` creates a list of preprocessors and then looks for extensions to add to that list using `stevedore`_::
+
+    try:
+        stevedore_mgr = extension.ExtensionManager(
+            namespace="eregs_ns.parser.preprocessors", invoke_on_load=False)
+        stevedore_mgr.map(lambda ext: PREPROCESSORS.append(ext.entry_point_target))
+    except NoMatches:
+        pass
+
+Both ``regparser/tree/xml_parser/xml_wrapper.py`` and ``regparser/builder.py`` import ``regparser/tree/xml_parser/extended_preprocessors.py``, which iterates through that list of preprocessors and imports the modules, and returns a list of them to be used.
+
+``regparser/commands/full_tests.py`` looks for extensions in the ``eregs_ns.parser.test_suite`` namespace and runs those in addition to `regulations-parser`_'s own tests.
+
+Future Extension Hooks
+----------------------
+A non-comprehensive list of other hooks we might add and what their namespaces would be:
+
+``ParagraphProcessors``
+    ``eregs_ns.parser.paragraph_processors``
+``Matchers``
+    ``eregs_ns.parser.matchers``
+Subtree Processors
+    ``eregs_ns.parser.subtree_processors``
+Tree Builders
+    ``eregs_ns.parser.tree_builders``
+``AppendixProcessors``
+    ``eregs_ns.parser.appendix_processors``
+
+
+.. _regulations-core: https://github.com/18F/regulations-core
+.. _regulations-parser: https://github.com/18F/regulations-parser
+.. _regulations-site: https://github.com/18F/regulations-site
+.. _fec-eregs: https://github.com/18F/fec-eregs
+.. _stevedore: http://docs.openstack.org/developer/stevedore/

--- a/eregs_extensions/fec_regparser/term_defs/__init__.py
+++ b/eregs_extensions/fec_regparser/term_defs/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+term_defs = {
+}
+
+ignores = {
+    "100": [
+        u"Federal Election Commission",  # exclude "Election" and "Commission"
+        u"Federal Election Campaign Act",  # exclude "Election"
+        u"United States"  # exclude "State"
+    ]
+}

--- a/eregs_extensions/setup.py
+++ b/eregs_extensions/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+
+ns = "eregs_ns.parser"  # The namespace for regulations-parser extensions.
+fs = "fec_regparser"  # The directory name for the package.
+entry_points = {
+    "%s.term_definitions" % ns: [
+        "fec_terms = %s.term_defs:term_defs" % fs
+    ],
+    "%s.term_ignores" % ns: [
+        "fec_ignore_terms = %s.term_defs:ignores" % fs
+    ]
+}
+
+setup(
+    name=fs,
+    version="1.0.0",
+    packages=find_packages(),
+    classifiers=[
+        'License :: Public Domain',
+        'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication'
+    ],
+    entry_points=entry_points
+)

--- a/fec_eregs/templates/regulations/partial-definition.html
+++ b/fec_eregs/templates/regulations/partial-definition.html
@@ -1,0 +1,60 @@
+{% comment %}
+    Partial for definitions to be displayed inline in the sidebar
+{% endcomment %}
+<div id="{{node.markup_id}}" class="open-definition" tabindex="0">
+    <div class="sidebar-header group">
+        <h4>
+            Defined Term
+            <a class="right close-button" href="#">Close definition</a>
+        </h4>
+    </div>
+
+    {% comment %}
+        Used to display scope warnings
+    {% endcomment %}
+    <div class="definition-warning hidden group">
+        <span class="cf-icon cf-icon-error icon-warning"></span>
+        <div class="msg">
+        </div>
+    </div>
+
+    <div class="definition-text">
+        {% if node.children %}
+
+                {% if node.marked_up %}
+                    <p>The first piece of this definition is:</p>
+
+                    <blockquote>
+                        {{node.marked_up|safe}}
+                    </blockquote>
+                {% else %}
+                    <p>This definition is best viewed in its original location.</p>
+                {% endif  %}
+        {% elif node.marked_up %}
+            <p>
+                {{node.marked_up|safe}}
+            </p>
+        {% endif  %}
+        {% if node.marked_up %}
+            <p>See the full definition at:</p>
+        {% endif  %}
+
+        <a  href="{% url 'chrome_section_view' node.section_id version %}#{{node.label_id}}"
+            class="continue-link full-def internal"
+            data-linked-section="{{node.label_id}}">{{formatted_label}}</a>
+
+        {% if not node.children %}
+            {% if node.interp %}
+                {% with interp=node.interp.interps.0 %}
+                <a  href="{% url 'chrome_subterp_view' interp.section_id version %}#{{ interp.label_id }}"
+                    data-linked-subsection="{{ interp.label_id }}"
+                    data-linked-section="{{ interp.section_id }}"
+                    class="internal interp continue-link">Official Interpretation</a>
+                {% endwith %}
+            {% endif %}
+        {% endif %}
+
+        <a class="close-button tab-activated" href="#">Close definition</a>
+    </div>
+
+</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ pyelasticsearch==1.4
 psycopg2==2.6.1
 waitress==0.8.10
 whitenoise==2.0.6
+
+-e eregs_extensions/


### PR DESCRIPTION
Add some exclusions (“Federal Election Commission”, “United States”, “Federal Election Campaign Act”), and make the definitions sidebar show the first paragraph of a definition that we think is longer than a paragraph as well as a link to the full definition.

Addresses https://github.com/18F/fec-eregs/issues/10 and https://trello.com/c/FC2ZnIqk/25-fec-eregs-links-to-defined-terms