### PR TITLE
FEC styling

### DIFF
--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -71,6 +71,15 @@ a {
   }
 }
 
+.definition,
+.definition:link,
+.definition:visited,
+.internal,
+.internal:link,
+.internal:visited {
+  border-bottom-style: dotted;
+}
+
 /*
  * Chrome overrides
  */

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -90,26 +90,25 @@ a {
 @toc-border: 1px solid @sand;
 @toc-background: @ivory;
 
+
+// Header
+.title a:link, .title a:visited,
+.app-nav a:link, .app-nav a:visited {
+  color: @primary;
+}
+
 .main-head {
   border-bottom: 3px solid @primary;
 }
 
-.panel {
-  background-color: @ivory;
-  border-right: @subhead-primary-border;
+.sub-head {
+  background-color: @cream;
+  border-bottom: @subhead-secondary-border;
+  color: @primary;
 }
 
-// TOC
-.drawer-header .toc-type, .toc-head {
-  border-right: @subhead-primary-border;
-}
 
-.subpart-heading {
-  background-color: @ivory;
-  border-bottom: @toc-border;
-  border-top: @toc-border;
-}
-
+// TOC header
 .toc-head {
   background-color: @cream;
   border-bottom: @subhead-secondary-border;
@@ -119,33 +118,45 @@ a {
   }
 }
 
-.regulation-nav a:link, .regulation-nav a:visited {
-  border-bottom: @toc-border;
-  color: @primary;
-}
-
-.drawer-header .toc-type {
-  background-color: @ivory;
-  border-bottom: @toc-border;
-}
-
-.toc-nav-link.current {
-  color: @cream;
-  background-color: @primary;
-}
-
-.sub-head {
-  background-color: @cream;
-  border-bottom: @subhead-secondary-border;
-  color: @primary;
-}
-
 .drawer-toggles li {
   border-right: @subhead-secondary-border;
 }
 
 .toc-nav-link {
   border-right: @subhead-secondary-border;
+
+  &.current {
+    color: @cream;
+    background-color: @primary;
+  }
+}
+
+
+// TOC
+.panel {
+  background-color: @ivory;
+  border-right: @subhead-primary-border;
+}
+
+.drawer-header .toc-type, .toc-head {
+  border-right: @subhead-primary-border;
+}
+
+.drawer-header .toc-type,
+{
+  background-color: @ivory;
+  border-bottom: @toc-border;
+}
+
+.subpart-heading {
+  background-color: @ivory;
+  border-bottom: @toc-border;
+  border-top: @toc-border;
+}
+
+.regulation-nav a:link, .regulation-nav a:visited {
+  border-bottom: @toc-border;
+  color: @primary;
 }
 
 // FEC is less boxy
@@ -169,10 +180,4 @@ a {
   .expand-drawer {
     border-bottom: @toc-border;
   }
-}
-
-// Header
-.title a:link, .title a:visited,
-.app-nav a:link, .app-nav a:visited {
-  color: @primary;
 }

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -57,7 +57,8 @@
  */
 .app-nav-list,
 .expandable,
-.reg-list {
+.reg-list,
+.toc-head {
   a {
     border-bottom: none;
   }
@@ -68,4 +69,101 @@ a {
   &.next-prev-link {
     border-bottom: none;
   }
+}
+
+/*
+ * Chrome overrides
+ */
+
+@subhead-primary-border: 2px solid @primary;
+@subhead-secondary-border: 1px solid @primary;
+@subhead-background: @cream;
+@toc-border: 1px solid @sand;
+@toc-background: @ivory;
+
+.main-head {
+  border-bottom: 3px solid @primary;
+}
+
+.panel {
+  background-color: @ivory;
+  border-right: @subhead-primary-border;
+}
+
+// TOC
+.drawer-header .toc-type, .toc-head {
+  border-right: @subhead-primary-border;
+}
+
+.subpart-heading {
+  background-color: @ivory;
+  border-bottom: @toc-border;
+  border-top: @toc-border;
+}
+
+.toc-head {
+  background-color: @cream;
+  border-bottom: @subhead-secondary-border;
+
+  a:hover {
+    background-color: @primary;
+  }
+}
+
+.regulation-nav a:link, .regulation-nav a:visited {
+  border-bottom: @toc-border;
+  color: @primary;
+}
+
+.drawer-header .toc-type {
+  background-color: @ivory;
+  border-bottom: @toc-border;
+}
+
+.toc-nav-link.current {
+  color: @cream;
+  background-color: @primary;
+}
+
+.sub-head {
+  background-color: @cream;
+  border-bottom: @subhead-secondary-border;
+  color: @primary;
+}
+
+.drawer-toggles li {
+  border-right: @subhead-secondary-border;
+}
+
+.toc-nav-link {
+  border-right: @subhead-secondary-border;
+}
+
+// FEC is less boxy
+.regulation-nav a {
+  padding: 10px 5px;
+  margin: 0 10px;
+}
+
+
+// Sidebar, Secondary content
+//
+// This component should match they styles of the toc.
+.secondary-content {
+  border-left: @toc-border;
+
+  .expandable {
+    background-color: @ivory;
+    border-bottom: @toc-border;
+  }
+
+  .expand-drawer {
+    border-bottom: @toc-border;
+  }
+}
+
+// Header
+.title a:link, .title a:visited,
+.app-nav a:link, .app-nav a:visited {
+  color: @primary;
 }

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -118,13 +118,22 @@ a {
   }
 }
 
-.drawer-toggles li {
-  border-right: @subhead-secondary-border;
+.drawer-toggles {
+  li { border-right: @subhead-secondary-border; }
+
+  .close & {
+    border-top: @subhead-secondary-border;
+
+    li { border-bottom: @subhead-secondary-border; }
+  }
 }
 
 .toc-nav-link {
   border-right: @subhead-secondary-border;
 
+  .close &.current,
+  .close &:hover,
+  &:hover,
   &.current {
     color: @cream;
     background-color: @primary;
@@ -136,6 +145,46 @@ a {
 .panel {
   background-color: @ivory;
   border-right: @subhead-primary-border;
+}
+
+.panel-slide {
+  img { display:none; }
+  img#open { display:none; }
+  img#close { display:inline-block; }
+  img#open-active { display:none; }
+  img#close-active { display:none; }
+
+  &:active,
+  &:hover {
+    img#close { display:none; }
+    img#close-active { display:inline-block; }
+  }
+
+  .close & {
+    border-bottom: @subhead-secondary-border;
+    img#close { display:none; }
+    img#open { display:inline-block; }
+
+    &:active,
+    &:hover {
+      img#open { display:none; }
+      img#open-active { display:inline-block; }
+      img#close-active { display:none; }
+    }
+  }
+}
+
+.toc-nav-link {
+  .drawer-toggle-icon.active { display:none; }
+
+  .closed &:hover,
+  .closed &.current,
+  &:hover,
+  &.current {
+    background: @primary;
+    .drawer-toggle-icon { display:none; }
+    .drawer-toggle-icon.active { display:inline-block; }
+  }
 }
 
 .drawer-header .toc-type, .toc-head {

--- a/fec_eregs/static/regulations/css/less/variables.less
+++ b/fec_eregs/static/regulations/css/less/variables.less
@@ -37,6 +37,8 @@ variables.less contains all theme variable / variable overrides
 @beige-dark: #c09c7c;
 @black: #000205;
 
+@sand: #e7dbbf;
+
 @disabled: #737373;
 
 // Color aliases

--- a/fec_eregs/static/regulations/img/close-caret-blue.svg
+++ b/fec_eregs/static/regulations/img/close-caret-blue.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   style="enable-background:new 0 0 1000 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="close-caret-blue.svg"><metadata
+     id="metadata11"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs9" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="0.236"
+     inkscape:cx="-586.86441"
+     inkscape:cy="500"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style3">
+	.st0{fill:#666666;}
+</style><path
+     class="st0"
+     d="M689.6,0c31.2,0,62.3,11.9,86.2,35.7c47.7,47.7,47.7,124.9,0,172.5L483.9,500l291.8,291.8  c47.7,47.6,47.7,124.8,0,172.4c-47.5,47.6-124.7,47.7-172.3,0.1L225.2,586.2c-22.9-22.8-35.7-53.9-35.7-86.2  c0-32.4,12.8-63.4,35.7-86.2L603.3,35.6C627.1,11.8,658.3,0,689.6,0z"
+     id="path5"
+     style="fill:#022c53;fill-opacity:1" /></svg>

--- a/fec_eregs/static/regulations/img/close-caret.svg
+++ b/fec_eregs/static/regulations/img/close-caret.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   style="enable-background:new 0 0 1000 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="close-caret.svg"><metadata
+     id="metadata11"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs9" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="0.236"
+     inkscape:cx="500"
+     inkscape:cy="500"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style3">
+	.st0{fill:#666666;}
+</style><path
+     class="st0"
+     d="M689.6,0c31.2,0,62.3,11.9,86.2,35.7c47.7,47.7,47.7,124.9,0,172.5L483.9,500l291.8,291.8  c47.7,47.6,47.7,124.8,0,172.4c-47.5,47.6-124.7,47.7-172.3,0.1L225.2,586.2c-22.9-22.8-35.7-53.9-35.7-86.2  c0-32.4,12.8-63.4,35.7-86.2L603.3,35.6C627.1,11.8,658.3,0,689.6,0z"
+     id="path5"
+     style="fill:#ffffff" /></svg>

--- a/fec_eregs/static/regulations/img/open-caret-blue.svg
+++ b/fec_eregs/static/regulations/img/open-caret-blue.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   style="enable-background:new 0 0 1000 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="open-caret-blue.svg"><metadata
+     id="metadata22"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs20" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="0.236"
+     inkscape:cx="-586.86441"
+     inkscape:cy="500"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style14">
+	.st0{fill:#666666;}
+</style><path
+     class="st0"
+     d="M311.4,1000c-31.2,0-62.3-11.9-86.2-35.7c-47.7-47.7-47.7-124.9,0-172.5L517.1,500L225.2,208.1  c-47.7-47.6-47.7-124.8,0-172.4C272.7-11.9,350-12,397.5,35.6l378.2,378.1c22.9,22.8,35.7,53.9,35.7,86.2  c0,32.4-12.8,63.4-35.7,86.2L397.6,964.3C373.8,988.1,342.6,1000,311.4,1000z"
+     id="path16"
+     style="fill:#022c53;fill-opacity:1" /></svg>

--- a/fec_eregs/static/regulations/img/open-caret.svg
+++ b/fec_eregs/static/regulations/img/open-caret.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   style="enable-background:new 0 0 1000 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="open-caret.svg"><metadata
+     id="metadata22"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs20" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="0.236"
+     inkscape:cx="500"
+     inkscape:cy="500"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style14">
+	.st0{fill:#666666;}
+</style><path
+     class="st0"
+     d="M311.4,1000c-31.2,0-62.3-11.9-86.2-35.7c-47.7-47.7-47.7-124.9,0-172.5L517.1,500L225.2,208.1  c-47.7-47.6-47.7-124.8,0-172.4C272.7-11.9,350-12,397.5,35.6l378.2,378.1c22.9,22.8,35.7,53.9,35.7,86.2  c0,32.4-12.8,63.4-35.7,86.2L397.6,964.3C373.8,988.1,342.6,1000,311.4,1000z"
+     id="path16"
+     style="fill:#ffffff" /></svg>

--- a/fec_eregs/static/regulations/img/search-blue.svg
+++ b/fec_eregs/static/regulations/img/search-blue.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   style="enable-background:new 0 0 1000 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="search-blue.svg"><metadata
+     id="metadata11"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs9" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="1.888"
+     inkscape:cx="97.252599"
+     inkscape:cy="540.16493"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style3">
+	.st0{fill:#666666;}
+</style><path
+     class="st0"
+     d="M979.5,881.8L636,538.1c36.6-54.7,57.8-120.6,57.8-191.2C693.8,155.6,538.2,0.1,347,0.1  C155.4,0.2,0,155.6,0,346.9c0,191.4,155.4,346.9,346.9,346.9c70.4,0,136.4-21.2,191.2-57.7l343.5,343.7  c13.3,13.6,31.3,20.3,49.1,20.3c17.7,0,35.5-6.8,48.9-20.3C1006.8,952.7,1006.8,908.7,979.5,881.8z M83.2,346.9  c0-145.3,118.3-263.6,263.7-263.6c145.3,0,263.5,118.2,263.5,263.6S492.2,610.6,346.9,610.6C201.5,610.6,83.2,492.4,83.2,346.9z"
+     id="path5"
+     style="fill:#022c53;fill-opacity:1" /></svg>

--- a/fec_eregs/static/regulations/img/search.svg
+++ b/fec_eregs/static/regulations/img/search.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   style="enable-background:new 0 0 1000 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="search.svg"><metadata
+     id="metadata11"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs9" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1501"
+     inkscape:window-height="1304"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="1.888"
+     inkscape:cx="233.11065"
+     inkscape:cy="540.16493"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style3">
+	.st0{fill:#666666;}
+</style><path
+     class="st0"
+     d="M979.5,881.8L636,538.1c36.6-54.7,57.8-120.6,57.8-191.2C693.8,155.6,538.2,0.1,347,0.1  C155.4,0.2,0,155.6,0,346.9c0,191.4,155.4,346.9,346.9,346.9c70.4,0,136.4-21.2,191.2-57.7l343.5,343.7  c13.3,13.6,31.3,20.3,49.1,20.3c17.7,0,35.5-6.8,48.9-20.3C1006.8,952.7,1006.8,908.7,979.5,881.8z M83.2,346.9  c0-145.3,118.3-263.6,263.7-263.6c145.3,0,263.5,118.2,263.5,263.6S492.2,610.6,346.9,610.6C201.5,610.6,83.2,492.4,83.2,346.9z"
+     id="path5"
+     style="fill:#ffffff" /></svg>

--- a/fec_eregs/static/regulations/img/table-of-contents-blue.svg
+++ b/fec_eregs/static/regulations/img/table-of-contents-blue.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1403.5 1000"
+   style="enable-background:new 0 0 1403.5 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="table-of-contents-blue.svg"><metadata
+     id="metadata43"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs41" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview39"
+     showgrid="false"
+     inkscape:zoom="0.944"
+     inkscape:cx="660.43613"
+     inkscape:cy="516.71558"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style25">
+	.st0{fill:#666666;}
+</style><g
+     id="g27"
+     style="fill:#022c53;fill-opacity:1"><path
+       class="st0"
+       d="M1298.2,210H479.3c-58.2,0-105.1-47-105.1-105.1c0-58.2,46.9-105.1,105.1-105.1h818.9   c58.2,0,105.3,47,105.3,105.1S1356.5,210,1298.2,210z M1403.5,499.6c0-58.2-47-105.1-105.3-105.1H479.3   c-58.2,0-105.1,47-105.1,105.1s46.9,105.1,105.1,105.1h818.9C1356.5,604.8,1403.5,557.8,1403.5,499.6z M1403.5,894.4   c0-58.1-47-105.1-105.3-105.1H479.3c-58.2,0-105.1,47-105.1,105.1c0,58.2,46.9,105.1,105.1,105.1h818.9   C1356.5,999.5,1403.5,952.6,1403.5,894.4z"
+       id="path29"
+       style="fill:#022c53;fill-opacity:1" /><path
+       class="st0"
+       d="M210.5,105.1c0,58.1-47.2,105.4-105.3,105.4C47,210.5,0,163.3,0,105.1S47-0.4,105.3-0.4   C163.4-0.2,210.5,46.8,210.5,105.1z"
+       id="path31"
+       style="fill:#022c53;fill-opacity:1" /><path
+       class="st0"
+       d="M210.5,105.1c0,58.1-47.2,105.4-105.3,105.4C47,210.5,0,163.3,0,105.1S47-0.4,105.3-0.4   C163.4-0.2,210.5,46.8,210.5,105.1z"
+       id="path33"
+       style="fill:#022c53;fill-opacity:1" /><path
+       class="st0"
+       d="M210.5,499.6c0,58.2-47.2,105.4-105.3,105.4C47,605,0,557.8,0,499.6s47-105.4,105.3-105.4   C163.4,394.3,210.5,441.5,210.5,499.6z"
+       id="path35"
+       style="fill:#022c53;fill-opacity:1" /><path
+       class="st0"
+       d="M210.5,894.2c0,58.2-47.2,105.4-105.3,105.4C47,999.6,0,952.5,0,894.2c0-58.1,47-105.4,105.3-105.4   C163.4,788.8,210.5,836,210.5,894.2z"
+       id="path37"
+       style="fill:#022c53;fill-opacity:1" /></g></svg>

--- a/fec_eregs/static/regulations/img/table-of-contents.svg
+++ b/fec_eregs/static/regulations/img/table-of-contents.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1403.5 1000"
+   style="enable-background:new 0 0 1403.5 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="table-of-contents.svg"><metadata
+     id="metadata43"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs41" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview39"
+     showgrid="false"
+     inkscape:zoom="0.236"
+     inkscape:cx="701.75"
+     inkscape:cy="500"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style25">
+	.st0{fill:#666666;}
+</style><g
+     id="g27"
+     style="fill:#ffffff"><path
+       class="st0"
+       d="M1298.2,210H479.3c-58.2,0-105.1-47-105.1-105.1c0-58.2,46.9-105.1,105.1-105.1h818.9   c58.2,0,105.3,47,105.3,105.1S1356.5,210,1298.2,210z M1403.5,499.6c0-58.2-47-105.1-105.3-105.1H479.3   c-58.2,0-105.1,47-105.1,105.1s46.9,105.1,105.1,105.1h818.9C1356.5,604.8,1403.5,557.8,1403.5,499.6z M1403.5,894.4   c0-58.1-47-105.1-105.3-105.1H479.3c-58.2,0-105.1,47-105.1,105.1c0,58.2,46.9,105.1,105.1,105.1h818.9   C1356.5,999.5,1403.5,952.6,1403.5,894.4z"
+       id="path29"
+       style="fill:#ffffff" /><path
+       class="st0"
+       d="M210.5,105.1c0,58.1-47.2,105.4-105.3,105.4C47,210.5,0,163.3,0,105.1S47-0.4,105.3-0.4   C163.4-0.2,210.5,46.8,210.5,105.1z"
+       id="path31"
+       style="fill:#ffffff" /><path
+       class="st0"
+       d="M210.5,105.1c0,58.1-47.2,105.4-105.3,105.4C47,210.5,0,163.3,0,105.1S47-0.4,105.3-0.4   C163.4-0.2,210.5,46.8,210.5,105.1z"
+       id="path33"
+       style="fill:#ffffff" /><path
+       class="st0"
+       d="M210.5,499.6c0,58.2-47.2,105.4-105.3,105.4C47,605,0,557.8,0,499.6s47-105.4,105.3-105.4   C163.4,394.3,210.5,441.5,210.5,499.6z"
+       id="path35"
+       style="fill:#ffffff" /><path
+       class="st0"
+       d="M210.5,894.2c0,58.2-47.2,105.4-105.3,105.4C47,999.6,0,952.5,0,894.2c0-58.1,47-105.4,105.3-105.4   C163.4,788.8,210.5,836,210.5,894.2z"
+       id="path37"
+       style="fill:#ffffff" /></g></svg>

--- a/fec_eregs/static/regulations/img/timeline-blue.svg
+++ b/fec_eregs/static/regulations/img/timeline-blue.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1417.8 1000"
+   style="enable-background:new 0 0 1417.8 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="timeline-blue.svg"><metadata
+     id="metadata58"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs56" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview54"
+     showgrid="false"
+     inkscape:zoom="0.944"
+     inkscape:cx="463.75356"
+     inkscape:cy="496.73649"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style46">
+	.st0{fill:#666666;}
+</style><g
+     id="g48"
+     style="fill:#022c53;fill-opacity:1"><path
+       class="st0"
+       d="M318.3,634.2c-3.1,0-6.5-0.6-9.6-1.8c-9.4-4-15.5-13-15.5-23.3V399.2c0-13.9,11.2-25.1,25.1-25.1   c14,0,25.2,11.2,25.2,25.1v149l62-62c9.8-9.8,25.7-9.8,35.6,0c9.8,9.8,9.8,25.8,0,35.6L336.2,626.8   C331.3,631.6,324.8,634.2,318.3,634.2z M637.5,571.9c0-175.7-143.1-318.7-318.7-318.7C142.9,253.2,0,396.3,0,571.9   s142.9,318.9,318.7,318.9C494.4,890.8,637.5,747.7,637.5,571.9z M570.4,571.9c0,138.8-112.9,251.5-251.7,251.5   c-138.7,0-251.5-112.9-251.5-251.5s112.9-251.5,251.5-251.5S570.4,433.3,570.4,571.9z"
+       id="path50"
+       style="fill:#022c53;fill-opacity:1" /><path
+       class="st0"
+       d="M627,336.6c80,88.9,83.9,176.9,83.9,237.8c0,92.9-31.6,178.5-83.9,247.1V956c0,24.4,19.7,44.2,44.2,44.2h702.4   c24.4,0,44.2-19.8,44.2-44.2V44.5c0-24.4-19.8-44.2-44.2-44.2H671.1c-24.5,0-44.2,19.8-44.2,44.2v157.9 M1283.6,845.8H783.5v-71.6   h500.1V845.8z M1283.6,679.7H783.5v-71.6h500.1V679.7z M1283.6,513.5l-500.1,5.8v-71.6l500.1-5.8V513.5z M1283.6,353.3l-500.1,5.8   v-71.6l500.1-5.8V353.3z M1283.6,193.2L783.5,199v-71.7l500.1-5.8V193.2z"
+       id="path52"
+       style="fill:#022c53;fill-opacity:1" /></g></svg>

--- a/fec_eregs/static/regulations/img/timeline.svg
+++ b/fec_eregs/static/regulations/img/timeline.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1417.8 1000"
+   style="enable-background:new 0 0 1417.8 1000;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="timeline.svg"><metadata
+     id="metadata58"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs56" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1471"
+     id="namedview54"
+     showgrid="false"
+     inkscape:zoom="0.944"
+     inkscape:cx="735.46966"
+     inkscape:cy="496.73649"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style46">
+	.st0{fill:#666666;}
+</style><g
+     id="g48"
+     style="fill:#ffffff"><path
+       class="st0"
+       d="M318.3,634.2c-3.1,0-6.5-0.6-9.6-1.8c-9.4-4-15.5-13-15.5-23.3V399.2c0-13.9,11.2-25.1,25.1-25.1   c14,0,25.2,11.2,25.2,25.1v149l62-62c9.8-9.8,25.7-9.8,35.6,0c9.8,9.8,9.8,25.8,0,35.6L336.2,626.8   C331.3,631.6,324.8,634.2,318.3,634.2z M637.5,571.9c0-175.7-143.1-318.7-318.7-318.7C142.9,253.2,0,396.3,0,571.9   s142.9,318.9,318.7,318.9C494.4,890.8,637.5,747.7,637.5,571.9z M570.4,571.9c0,138.8-112.9,251.5-251.7,251.5   c-138.7,0-251.5-112.9-251.5-251.5s112.9-251.5,251.5-251.5S570.4,433.3,570.4,571.9z"
+       id="path50"
+       style="fill:#ffffff" /><path
+       class="st0"
+       d="M627,336.6c80,88.9,83.9,176.9,83.9,237.8c0,92.9-31.6,178.5-83.9,247.1V956c0,24.4,19.7,44.2,44.2,44.2h702.4   c24.4,0,44.2-19.8,44.2-44.2V44.5c0-24.4-19.8-44.2-44.2-44.2H671.1c-24.5,0-44.2,19.8-44.2,44.2v157.9 M1283.6,845.8H783.5v-71.6   h500.1V845.8z M1283.6,679.7H783.5v-71.6h500.1V679.7z M1283.6,513.5l-500.1,5.8v-71.6l500.1-5.8V513.5z M1283.6,353.3l-500.1,5.8   v-71.6l500.1-5.8V353.3z M1283.6,193.2L783.5,199v-71.7l500.1-5.8V193.2z"
+       id="path52"
+       style="fill:#ffffff" /></g></svg>

--- a/fec_eregs/templates/regulations/chrome.html
+++ b/fec_eregs/templates/regulations/chrome.html
@@ -1,0 +1,39 @@
+{% overextends "regulations/chrome.html" %}
+{% load static from staticfiles %}
+
+{% block sidebar-drawer-icons %}
+<a href="#" id="panel-link" class="toc-toggle panel-slide">
+  <img id="open-active" src="{%static "regulations/img/open-caret.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
+  <img id="open" src="{%static "regulations/img/open-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
+  <img id="close" src="{%static "regulations/img/close-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
+  <img id="close-active" src="{%static "regulations/img/close-caret.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
+</a>
+{% endblock %}
+
+{% block sidebar-toc-link %}
+<li>
+  <a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Table of Contents">
+    <span class="icon-text">Table of Contents</span>
+    <img src="{%static "regulations/img/table-of-contents.svg" %}" class="drawer-toggle-icon active" alt="Table of Contents toggle" />
+    <img src="{%static "regulations/img/table-of-contents-blue.svg" %}" class="drawer-toggle-icon" alt="Table of Contents toggle" />
+  </a>
+</li>
+{% endblock %}
+{% block sidebar-history-link %}
+<li>
+  <a href="#timeline" id="timeline-link" class="toc-nav-link" title="Regulation Timeline">
+    <span class="icon-text">Regulation Timeline</span>
+    <img src="{%static "regulations/img/timeline.svg" %}" class="drawer-toggle-icon active" alt="Regulation Timeline toggle"/>
+    <img src="{%static "regulations/img/timeline-blue.svg" %}" class="drawer-toggle-icon" alt="Regulation Timeline toggle"/>
+  </a>
+</li>
+{% endblock %}
+{% block sidebar-search-link %}
+<li>
+  <a href="#search" id="search-link" class="toc-nav-link" title="Search">
+    <span class="icon-text">Search</span>
+    <img src="{%static "regulations/img/search.svg" %}" class="drawer-toggle-icon active" alt="Search toggle"/>
+    <img src="{%static "regulations/img/search-blue.svg" %}" class="drawer-toggle-icon" alt="Search toggle"/>
+  </a>
+</li>
+{% endblock %}


### PR DESCRIPTION
Some more styles based on feedback. Includes colored icons for highlight treatments. This is dependent on a fork of [regulations-site](https://github.com/18F/regulations-site/pull/139).

![screenshot from 2016-03-21 23-23-58](https://cloud.githubusercontent.com/assets/509703/13943722/1ffef4ea-efbc-11e5-8fc5-02c605cb6fcc.png)
![screenshot from 2016-03-21 23-24-23](https://cloud.githubusercontent.com/assets/509703/13943726/26c27018-efbc-11e5-8454-3a850eaf7edd.png)