### PR TITLE
Make Django test use the right test runner

### DIFF
--- a/fec_eregs/settings/base.py
+++ b/fec_eregs/settings/base.py
@@ -17,6 +17,8 @@ NOSE_ARGS = [
     '--verbosity=3'
 ]
 
+TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
+
 ROOT_URLCONF = 'fec_eregs.urls'
 
 DATABASES = REGCORE_DATABASES


### PR DESCRIPTION
Add line to make sure the Django tests of reg-core and reg-site use the Django test runner, something that stymied me for quite some time last week.