### PR TITLE
Notes/changes for better prod deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ the new front end, and push the result.
 ```bash
 $ pip install -r requirements.txt   # updates the -core/-site repositories
 $ python manage.py compile_frontend   # builds the frontend
-$ cf push
+$ cf push -f manifest.prod.yml
 ```
 
 Confusingly, although the front-end compilation step occurs locally, all other
@@ -127,3 +127,16 @@ will pull in the latest from `regulations-site` and `regulations-core`,
 regardless of what you have locally and regardless of what you've built the
 front-end against. Be sure to always update your local libraries (via `pip`)
 before building and pushing.
+
+
+### Environments
+
+We're currently deploying to multiple environments, a `dev` and a `prod`
+instance. `dev` is continuously deployed from
+[travis-ci](https://travis-ci.org/), while `prod` is deployed occasionally,
+manually using the instructions above.
+
+Environment | URL | Description
+----------- | --- | -----------
+`dev`       | https://fec-eregs-dev.apps.cloud.gov/ | Ad-hoc testing, deploys the latest changes from `master`.
+`prod`      | https://fec-eregs.apps.cloud.gov/     | Production site, deployed manually.

--- a/fec_eregs/settings/prod.py
+++ b/fec_eregs/settings/prod.py
@@ -2,8 +2,11 @@ import json
 import os
 
 import dj_database_url
+from cfenv import AppEnv
 
 from .base import *
+
+env = AppEnv()
 
 DEBUG = False
 TEMPLATE_DEBUG = False
@@ -26,3 +29,6 @@ if es_config:
         'URL': es_config[0]['credentials']['uri'],
         'INDEX_NAME': 'eregs',
     }
+
+HTTP_AUTH_USER = env.get_credential('HTTP_AUTH_USER')
+HTTP_AUTH_PASSWORD = env.get_credential('HTTP_AUTH_PASSWORD')

--- a/manifest.prod.yml
+++ b/manifest.prod.yml
@@ -1,6 +1,6 @@
 ---
 inherit: manifest.base.yml
 host: fec-eregs
-instances: 5
+instances: 2
 applications:
   - name: fec-eregs

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ requests==2.8.1
 -e git+https://github.com/18F/regulations-site.git#egg=regulations
 
 # fec-specific/cloud.gov
+cfenv==0.5.2
 dj-database-url==0.3.0
 django-overextends==0.4.0
 pyelasticsearch==1.4


### PR DESCRIPTION
Some notes on our environments in the README.

For `prod`, we're storing the HTTP creds to update the api in a [cf user-provided service](https://docs.cloudfoundry.org/devguide/services/user-provided.html). This includes a settings change to read those creds from this service.