### PR TITLE
Mount app under /legal-viewer for betaFEC integration

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -62,3 +62,4 @@ local_settings.py
 
 # Local frontend build
 frontend_build/
+node_modules/

--- a/fec_eregs/settings/base.py
+++ b/fec_eregs/settings/base.py
@@ -27,3 +27,4 @@ API_BASE = 'http://localhost:{}/api/'.format(
     os.environ.get('VCAP_APP_PORT', '8000'))
 
 STATICFILES_DIRS = ['compiled']
+STATIC_URL = '/legal-viewer/static/'

--- a/fec_eregs/settings/prod.py
+++ b/fec_eregs/settings/prod.py
@@ -19,7 +19,9 @@ DATABASES = {
 
 
 vcap_app = json.loads(os.environ.get('VCAP_APPLICATION', '{}'))
-ALLOWED_HOSTS = ['localhost'] + vcap_app.get('application_uris', [])
+
+# application_uris might contain paths when a route with path is mapped
+ALLOWED_HOSTS = ['localhost'] + [uri.split('/', 1)[0] for uri in vcap_app.get('application_uris', [])]
 
 vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
 es_config = vcap_services.get('elasticsearch-swarm-1.7.1', [])

--- a/fec_eregs/urls.py
+++ b/fec_eregs/urls.py
@@ -4,6 +4,10 @@ from regcore import urls as regcore_urls
 from regulations import urls as regsite_urls
 
 
-urlpatterns = [
+extra_patterns = [
     url(r'^api/', include(regcore_urls))
 ] + regsite_urls.urlpatterns
+
+urlpatterns = [
+    url(r'^legal-viewer/', include(extra_patterns))
+]


### PR DESCRIPTION
Using Cloud Foundry's `map-route` command, we can specify a path to be routed to a specific app. This seems like a good use case to get the eregs viewer under the betaFEC domain.

Here's an example of the two apps running under the same domain:
https://fec-web-adborden.18f.gov/legal/search
https://fec-web-adborden.18f.gov/legal-viewer/4-4/2015-annual-4#4-4

I'm no django expert, so would love to know if there's a cleaner way to handle this (like maybe via an env variable).

If we were to go ahead with this strategy I would suggest these additional changes:

- [ ] Fix the tests (or disable them as appropriate)
- [ ] Add a "/" route for dev which re-directs you to a working page, rather than a 404