### PR TITLE
Prefer test_utils versions of libraries

### DIFF
--- a/eregs_extensions/extensions-outline.rst
+++ b/eregs_extensions/extensions-outline.rst
@@ -60,10 +60,8 @@ And would likely need ``etree``::
 They would also need tests. The tests would need the following import lines::
 
     from unittest import TestCase
-    from tests.xml_builder import XMLBuilderMixin
     from mib_regparser.preprocs import <whatever the test is for>
-
-The ``tests.xml_builder`` namespacing is problematic and will probably be changed to ``regparser.tests.xml_builder`` soon.
+    from regparser.test_utils.xml_builder import XMLBuilder
 
 Note that the test has to reflect the filesystem name ``mib_regparser``—in other words, each test has to change if that name changes.
 

--- a/eregs_extensions/fec_regparser/tests/preprocessor_tests.py
+++ b/eregs_extensions/fec_regparser/tests/preprocessor_tests.py
@@ -1,11 +1,11 @@
 # vim: set encoding=utf-8
 from unittest import TestCase
 
-from tests.xml_builder import XMLBuilderMixin
 from fec_regparser.preprocs import RepeatedEmphasis
+from regparser.test_utils.xml_builder import XMLBuilder
 
 
-class RepeatedEmphasisTests(XMLBuilderMixin, TestCase):
+class RepeatedEmphasisTests(TestCase):
     """
     We want to change e.g.:
 
@@ -15,19 +15,24 @@ class RepeatedEmphasisTests(XMLBuilderMixin, TestCase):
 
         <P>(d) <E T="03">[Term]</E>. <E T="03">[Term]</E> [text]</P>
     """
+    @staticmethod
+    def _emphasis_from(paragraph_text):
+        """Setup for several tests"""
+        with XMLBuilder("PART") as ctx:
+            with ctx.REGTEXT(ID="RT1"):
+                with ctx.SECTION():
+                    ctx.SECTNO(u"§ 100.2")
+                    ctx.SUBJECT("Election (52 U.S.C. 30101(1)).")
+                    ctx.child_from_string('<P>{}</P>'.format(paragraph_text))
+        xml = ctx.xml
+        RepeatedEmphasis().transform(xml)
+        return xml.xpath("//E")
+
     def test_repeated_emphasis_transform(self):
         runoff = u"%s %s %s" % (u'(d) <E T="03">Runoff election. Runoff',
                                 u'election</E> means the election which meets',
                                 u'either of the following conditions:')
-        with self.tree.builder("PART") as part:
-            with part.REGTEXT(ID="RT1") as regtext:
-                with regtext.SECTION() as section:
-                    section.SECTNO(u"§ 100.2")
-                    section.SUBJECT("Election (52 U.S.C. 30101(1)).")
-                    section.P(_xml=runoff)
-        xml = self.tree.render_xml()
-        RepeatedEmphasis().transform(xml)
-        e_elements = xml.xpath("//E")
+        e_elements = self._emphasis_from(runoff)
 
         self.assertEquals(len(e_elements), 2)
         self.assertEquals(e_elements[0].text, "Runoff election.")
@@ -46,15 +51,7 @@ class RepeatedEmphasisTests(XMLBuilderMixin, TestCase):
         runoff = u"%s %s %s" % (u'(d) <E T="03">Runoff election. Runoff',
                                 u'elector</E> means the election which meets',
                                 u'either of the following conditions:')
-        with self.tree.builder("PART") as part:
-            with part.REGTEXT(ID="RT1") as regtext:
-                with regtext.SECTION() as section:
-                    section.SECTNO(u"§ 100.2")
-                    section.SUBJECT("Election (52 U.S.C. 30101(1)).")
-                    section.P(_xml=runoff)
-        xml = self.tree.render_xml()
-        RepeatedEmphasis().transform(xml)
-        e_elements = xml.xpath("//E")
+        e_elements = self._emphasis_from(runoff)
 
         self.assertEquals(len(e_elements), 1)
         self.assertEquals(e_elements[0].text,
@@ -70,15 +67,7 @@ class RepeatedEmphasisTests(XMLBuilderMixin, TestCase):
         runoff = u"%s %s %s" % (u'(d) <E T="03">Runoff election Runoff',
                                 u'election</E> means the election which meets',
                                 u'either of the following conditions:')
-        with self.tree.builder("PART") as part:
-            with part.REGTEXT(ID="RT1") as regtext:
-                with regtext.SECTION() as section:
-                    section.SECTNO(u"§ 100.2")
-                    section.SUBJECT("Election (52 U.S.C. 30101(1)).")
-                    section.P(_xml=runoff)
-        xml = self.tree.render_xml()
-        RepeatedEmphasis().transform(xml)
-        e_elements = xml.xpath("//E")
+        e_elements = self._emphasis_from(runoff)
 
         self.assertEquals(len(e_elements), 1)
         self.assertEquals(e_elements[0].text,


### PR DESCRIPTION
Per eregs/regulations-parser#214, use the regparser namespaced test
libraries