### PR TITLE
Adding the django debug toolbar to dev environments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
     - pip install -r requirements.txt
     - pip install -r requirements_test.txt
+    - pip install -r requirements_dev.txt
     - npm install -g grunt-cli bower
     - npm install
 script:

--- a/fec_eregs/settings/dev.py
+++ b/fec_eregs/settings/dev.py
@@ -1,6 +1,7 @@
 from .base import *
 
 DEBUG = True
+INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)
 
 # Analytics settings
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,1 @@
+django-debug-toolbar==1.4


### PR DESCRIPTION
The Django Debug Toolbar is a handy tool that provides info about the templates, views, and queries each page of the app is using. [Here are the django debug toolbar docs](http://django-debug-toolbar.readthedocs.org/en/1.4/index.html) and [Here's the debug toolbar code](https://github.com/django-debug-toolbar/django-debug-toolbar).