### PR TITLE
[issue #18] display CFR title in arabic

### DIFF
--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -1,0 +1,4 @@
+{% overextends "regulations/generic_universal.html" %}
+{% load arabic %}
+
+{% block cfr_title %}Title {{cfr_title_number|arabic}} {{cfr_title_text}}{% endblock %}

--- a/fec_eregs/templatetags/arabic.py
+++ b/fec_eregs/templatetags/arabic.py
@@ -1,0 +1,11 @@
+from django import template
+from roman import fromRoman
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+@register.filter(name='arabic')
+@stringfilter
+def arabic(value):
+    #capitalizes roman numerals and converts to arabic.
+    return fromRoman(value.upper())

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ waitress==0.8.10
 whitenoise==2.0.6
 
 -e eregs_extensions/
+
+roman==2.0.0


### PR DESCRIPTION
Per https://github.com/18F/fec-eregs/issues/18 , switching the CFR title from roman numerals to arabic. Goes along with https://github.com/eregs/regulations-site/pull/271 , which @cmc333333 already merged because he is fast like lightning.