### PR TITLE
[issue #18] Display CFR title number in arabic numerals.

### DIFF
--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -1,0 +1,3 @@
+{% overextends "regulations/generic_universal.html" %}
+
+{% block cfr_title %}Title {{cfr_titleno_arabic}} {{cfr_title_text}}{% endblock %}


### PR DESCRIPTION
Per https://github.com/18F/fec-eregs/issues/18, CFR title should be in arabic. Depends on https://github.com/eregs/regulations-site/pull/272 , which @cmc333333 has already merged.