### PR TITLE
Update manifests as per FEC convention

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -62,3 +62,4 @@ local_settings.py
 
 # Local frontend build
 frontend_build/
+node_modules/

--- a/manifest.base.yml
+++ b/manifest.base.yml
@@ -7,3 +7,7 @@ services:
   - fec-eregs-search-1.7.1
 env:
   DJANGO_SETTINGS_MODULE: fec_eregs.settings.prod
+domain: 18f.gov
+applications:
+  - name: eregs
+    memory: 512M

--- a/manifest.dev.yml
+++ b/manifest.dev.yml
@@ -1,5 +1,3 @@
 ---
 inherit: manifest.base.yml
-host: fec-eregs-dev
-applications:
-  - name: fec-eregs-dev
+host: fec-dev-eregs

--- a/manifest.prod.yml
+++ b/manifest.prod.yml
@@ -1,6 +1,4 @@
 ---
 inherit: manifest.base.yml
-host: fec-eregs
+host: fec-prod-eregs
 instances: 2
-applications:
-  - name: fec-eregs


### PR DESCRIPTION
- Simple `eregs` app name
- Use 18f.gov domain
- Use host `fec-<env>-<app>`

Also ignore `node_modules` on `cf push`.