### PR TITLE
Sets up eregs to serve under a prefix

### DIFF
--- a/fec_eregs/settings/prod.py
+++ b/fec_eregs/settings/prod.py
@@ -1,10 +1,14 @@
 import json
+import logging
 import os
+import sys
 
 import dj_database_url
 from cfenv import AppEnv
 
 from .base import *
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 
 env = AppEnv()
 

--- a/fec_eregs/settings/prod.py
+++ b/fec_eregs/settings/prod.py
@@ -36,3 +36,5 @@ if es_config:
 
 HTTP_AUTH_USER = env.get_credential('HTTP_AUTH_USER')
 HTTP_AUTH_PASSWORD = env.get_credential('HTTP_AUTH_PASSWORD')
+
+STATIC_URL = '/regulations/static/'

--- a/fec_eregs/wsgi.py
+++ b/fec_eregs/wsgi.py
@@ -1,8 +1,20 @@
 import os
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fec_eregs.settings")
-# important that the whitenoise import is after the line above
-from whitenoise.django import DjangoWhiteNoise
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fec_eregs.settings.prod")
 
-application = DjangoWhiteNoise(get_wsgi_application())
+# important that the whitenoise import is after the line above
+from whitenoise import WhiteNoise
+from django.conf import settings
+
+# This is a work-around because whitenoise does not support SCRIPT_NAME.
+# https://github.com/evansd/whitenoise/issues/88
+#
+# We munge the prefix just enough that it works. Using the Django
+# WhiteNoiseMiddleware doesn't give us enough flexibility to get the behavior
+# we need.
+application = WhiteNoise(
+    get_wsgi_application(),
+    root=settings.STATIC_ROOT,
+    prefix='/static/'
+)

--- a/manifest.base.yml
+++ b/manifest.base.yml
@@ -1,6 +1,6 @@
 ---
 buildpack: python_buildpack
-command: python manage.py migrate --fake-initial && python manage.py rebuild_index --noinput --remove && python manage.py collectstatic --noinput && waitress-serve --port=$VCAP_APP_PORT fec_eregs.wsgi:application
+command: python manage.py migrate --fake-initial && python manage.py collectstatic --noinput && waitress-serve --url-prefix /regulations --port=$VCAP_APP_PORT fec_eregs.wsgi:application
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
   - fec-eregs-db

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,6 @@ django-overextends==0.4.0
 pyelasticsearch==1.4
 psycopg2==2.6.1
 waitress==0.8.10
-whitenoise==2.0.6
+whitenoise==3.0
 
 -e eregs_extensions/


### PR DESCRIPTION
[fec-proxy](https://github.com/18F/fec-proxy) allows apps to be routed using wsgi's SCRIPT_NAME. This mounts eregs under `/regulations` on betaFEC.

It seems that [whitenoise does not support SCRIPT_NAME](https://github.com/evansd/whitenoise/issues/88) but we were able to work around this by specifying the prefix explicitly.