### PR TITLE
[Issue #18] putting paragraph markers in parens.

### DIFF
--- a/fec_eregs/templates/regulations/node.html
+++ b/fec_eregs/templates/regulations/node.html
@@ -1,0 +1,7 @@
+{% overextends "regulations/node.html" %}
+
+{% block paragraph_marker %}
+{% if node.paragraph_marker %}
+<span class="stripped-marker">({{node.paragraph_marker}})</span>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Per https://github.com/18F/fec-eregs/issues/18, overriding the paragraph marker block to display markers in parens. Goes with https://github.com/eregs/regulations-site/pull/356.
