### PR TITLE
Feature/add search to landing page

### DIFF
--- a/fec_eregs/static/fec_eregs/scss/main.scss
+++ b/fec_eregs/static/fec_eregs/scss/main.scss
@@ -38,8 +38,11 @@ $x-large-screen: 1100px;
 @import 'elements/tables';
 @import 'elements/images';
 
+@import 'components/form-styles';
 @import 'components/list-styles';
 @import 'components/mega-menu';
+@import 'components/search-bar';
+@import 'components/buttons';
 
 @import 'modules/site-header';
 @import 'modules/nav';
@@ -48,3 +51,4 @@ $x-large-screen: 1100px;
 @import 'headings';
 @import 'components';
 
+@import 'layout/layout';

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -160,7 +160,8 @@ html, body, .landing-content, .search-panel {
 }
 
 .search-box button {
-  background-color: @gray-medium;
+  background-color: @gray;
+  padding-top: 5px;
 }
 
 .search-header {
@@ -179,6 +180,10 @@ html, body, .landing-content, .search-panel {
 
 .reg-list {
   border-top: none;
+}
+
+.content-primary {
+  width: 100%;
 }
 
 // TOC

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -165,7 +165,7 @@ html, body, .landing-content, .search-panel {
 }
 
 .search-header {
-  border-bottom: 2px solid #112e51;
+  border-bottom: 2px solid @gray;
   margin-bottom: 2rem;
   padding: .5rem;
   font-size: 1.5rem;

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -144,6 +144,42 @@ a {
   }
 }
 
+// Landing page search
+
+html, body, .landing-content, .search-panel {
+  height: 100%;
+}
+
+.search-panel {
+  background-color: @toc-background;
+}
+
+.search-box input[type="text"] {
+  float: left;
+  border-radius: 0px;
+}
+
+.search-box button {
+  background-color: @gray-medium;
+}
+
+.search-header {
+  border-bottom: 2px solid #112e51;
+  margin-bottom: 2rem;
+  padding: .5rem;
+  font-size: 1.5rem;
+  font-family: ghandi, serif;
+  text-align: center;
+}
+
+.regulations-title {
+  border-bottom: 2px solid #112e51;
+  padding-bottom: 10px;
+}
+
+.reg-list {
+  border-top: none;
+}
 
 // TOC
 .panel {

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -37,6 +37,8 @@
  */
 .reg-header {
   font-family: @serif;
+  top: 0px;
+  left: 0px;
 }
 
 .version-search {
@@ -151,17 +153,7 @@ html, body, .landing-content, .search-panel {
 }
 
 .search-panel {
-  background-color: @toc-background;
-}
-
-.search-box input[type="text"] {
-  float: left;
-  border-radius: 0px;
-}
-
-.search-box button {
-  background-color: @gray;
-  padding-top: 5px;
+   background-color: @toc-background;
 }
 
 .search-header {

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -1,3 +1,96 @@
 {% overextends "regulations/generic_universal.html" %}
 
-{% block cfr_title %}Title {{cfr_titleno_arabic}} {{cfr_title_text}}{% endblock %}
+{% block body %}
+<header id="site-header" class="reg-header">
+    {% include "regulations/main-header.html" %}
+</header>
+
+<div class="landing-content">
+<div class="usa-width-one-fourth search-panel">
+  <div id="search" class="search-drawer toc-container hidden">
+    <form action="/data/legal/regulations/" method="GET" role="search">
+        <div class="search-box">
+            <div class="search-header">Search Regulations</div>
+            <label for="search-input">Terms</label>
+            <input type="text" name="search" id="search-input" title="Search term"/>
+            <button type="submit"><span class="cf-icon cf-icon-search"></span>
+              <strong class="icon-text">Search</strong></button>
+            <input type="hidden" name="search_type" id="version-hidden" title="Search Type" value="regulations"/>
+        </div><!--/.search-box-->
+    </form>
+</div>
+</div>
+<div class="usa-width-three-fourths" role="main">
+  <div class="inner-wrap">
+
+    <div class="group">
+      <div class="content-primary column-l bump">
+        <div class="regulations-title">
+        <h2>Regulations</h2>
+        <h2 class="small-header">
+            {% block cfr_title %}Title {{cfr_titleno_arabic}} {{cfr_title_text}}{% endblock %}
+        </h2>
+      </div>
+        <ul class="reg-list">
+            {% for regulation in regulations %}
+                <li>
+                    <a href="{% url 'regulation_landing_view' regulation.part %}">
+                        <span class="title-num">{{regulation.part}}</span>
+                        <div class="reg-sub-title">
+                            {% if regulation.meta.reg_letter %}
+                                <span class="reg-major-text">Regulation {{regulation.meta.reg_letter}}</span>
+                                <span class="reg-title">{{regulation.meta.statutory_name|title}}</span>
+                            {% else %}
+                                <span class="reg-major-text">{{regulation.meta.statutory_name|title}}</span>
+                            {% endif %}
+                        </div>
+                        <span class="cf-icon cf-icon-right-round"></span>
+                    </a>
+
+                    {% for amendment in regulation.amendments %}
+                        <div class="mini-alert important">
+                            New amendment effective {{amendment.by_date|date:'n/j/Y'}}
+                            <a href="{% url 'chrome_section_view' regulation.reg_first_section amendment.version %}" class="go">View new amendment</a>
+                        </div>
+                    {% endfor %}
+                </li>
+            {% endfor %}
+        </ul>
+
+        {% block moreregulations %}
+        {% endblock %}
+      </div> <!-- /.primary -->
+
+        {% block secondcolumn_notices %}
+        {% endblock %}
+    </div> <!-- /.group -->
+
+      <section class="about bump group">
+        <h2 class="light-header">About eRegulations</h2>
+        <div class="content-primary column-l">
+
+          <p>eRegulations is a web-based tool that makes regulations easier
+          to find, read and understand with features such as inline
+          official interpretations, highlighted defined terms, and a
+          revision comparison view.</p>
+
+          <p><a href="{% url 'about' %}" class="go">Learn more about eRegulations&#8217; features</a></p>
+        </div> <!-- /.primart -->
+
+        {% block orgcontact %}
+        {% endblock %}
+
+        {% block legal %}
+        {% endblock %}
+      </section> <!-- /.about -->
+  </div> <!-- /.inner-wrap -->
+</div> <!-- /.landing-main -->
+
+</div> <!-- /.landing-content -->
+
+{% include "regulations/full_footer.html" %}
+
+{% block endscripts %}
+{% endblock %}
+
+{% endblock %}

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -48,16 +48,9 @@
         {% endblock %}
     </div> <!-- /.group -->
 
-      <section class="about bump group">
         {% block about-eregs %}
         {{ block.super }}
         {% endblock %}
-        {% block orgcontact %}
-        {% endblock %}
-
-        {% block legal %}
-        {% endblock %}
-      </section> <!-- /.about -->
   </div> <!-- /.inner-wrap -->
 </div> <!-- /.landing-main -->
 

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -49,17 +49,9 @@
     </div> <!-- /.group -->
 
       <section class="about bump group">
-        <h2 class="light-header">About eRegulations</h2>
-        <div class="content-primary column-l">
-
-          <p>eRegulations is a web-based tool that makes regulations easier
-          to find, read and understand with features such as inline
-          official interpretations, highlighted defined terms, and a
-          revision comparison view.</p>
-
-          <p><a href="{% url 'about' %}" class="go">Learn more about eRegulations&#8217; features</a></p>
-        </div> <!-- /.primart -->
-
+        {% block about-eregs %}
+        {{ block.super }}
+        {% endblock %}
         {% block orgcontact %}
         {% endblock %}
 

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -9,7 +9,21 @@
 <div class="landing-content">
   {% block hero %} {% endblock %}
 <div class="usa-width-one-fourth search-panel">
-  <div id="search" class="search-drawer toc-container hidden">
+    <div class="container">
+      <div class="u-padding-left u-padding--right">
+          <div class="search-header">Search regulations</div>
+        <form action="/data/legal/regulations/" method="GET" role="search">
+            <div class="combo--search--mini">
+              <label class="label t-left-aligned" for="search-regs">Terms</label>
+              <input id="search-regs" name="search" class="combo__input" type="text" title="Search term"/>
+              <input type="hidden" name="search_type" id="version-hidden" title="Search Type" value="regulations"/>
+              <button class="combo__button button--search button--standard" type="submit"/>
+                <span class="u-visually-hidden">Search</span></button>
+            </div>
+          </form>
+        </div>
+    </div>
+    <!--
     <form action="/data/legal/regulations/" method="GET" role="search">
         <div class="search-box">
             <div class="search-header">Search regulations</div>
@@ -18,9 +32,9 @@
             <button type="submit"><img src="{% static "fec_eregs/img/i-search--primary.svg" %}"/>
               <strong class="icon-text">Search</strong></button>
             <input type="hidden" name="search_type" id="version-hidden" title="Search Type" value="regulations"/>
-        </div><!--/.search-box-->
+        </div>
     </form>
-</div>
+    !-->
 </div>
 <div class="usa-width-three-fourths" role="main">
   <div class="inner-wrap">

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -1,4 +1,5 @@
 {% overextends "regulations/generic_universal.html" %}
+{% load staticfiles %}
 
 {% block body %}
 <header id="site-header" class="reg-header">
@@ -10,10 +11,10 @@
   <div id="search" class="search-drawer toc-container hidden">
     <form action="/data/legal/regulations/" method="GET" role="search">
         <div class="search-box">
-            <div class="search-header">Search Regulations</div>
+            <div class="search-header">Search regulations</div>
             <label for="search-input">Terms</label>
             <input type="text" name="search" id="search-input" title="Search term"/>
-            <button type="submit"><span class="cf-icon cf-icon-search"></span>
+            <button type="submit"><img src="{% static "fec_eregs/img/i-search--primary.svg" %}"/>
               <strong class="icon-text">Search</strong></button>
             <input type="hidden" name="search_type" id="version-hidden" title="Search Type" value="regulations"/>
         </div><!--/.search-box-->

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -23,18 +23,6 @@
           </form>
         </div>
     </div>
-    <!--
-    <form action="/data/legal/regulations/" method="GET" role="search">
-        <div class="search-box">
-            <div class="search-header">Search regulations</div>
-            <label for="search-input">Terms</label>
-            <input type="text" name="search" id="search-input" title="Search term"/>
-            <button type="submit"><img src="{% static "fec_eregs/img/i-search--primary.svg" %}"/>
-              <strong class="icon-text">Search</strong></button>
-            <input type="hidden" name="search_type" id="version-hidden" title="Search Type" value="regulations"/>
-        </div>
-    </form>
-    !-->
 </div>
 <div class="usa-width-three-fourths" role="main">
   <div class="inner-wrap">

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -7,6 +7,7 @@
 </header>
 
 <div class="landing-content">
+  {% block hero %} {% endblock %}
 <div class="usa-width-one-fourth search-panel">
   <div id="search" class="search-drawer toc-container hidden">
     <form action="/data/legal/regulations/" method="GET" role="search">
@@ -26,37 +27,18 @@
 
     <div class="group">
       <div class="content-primary column-l bump">
-        <div class="regulations-title">
-        <h2>Regulations</h2>
-        <h2 class="small-header">
-            {% block cfr_title %}Title {{cfr_titleno_arabic}} {{cfr_title_text}}{% endblock %}
-        </h2>
-      </div>
-        <ul class="reg-list">
-            {% for regulation in regulations %}
-                <li>
-                    <a href="{% url 'regulation_landing_view' regulation.part %}">
-                        <span class="title-num">{{regulation.part}}</span>
-                        <div class="reg-sub-title">
-                            {% if regulation.meta.reg_letter %}
-                                <span class="reg-major-text">Regulation {{regulation.meta.reg_letter}}</span>
-                                <span class="reg-title">{{regulation.meta.statutory_name|title}}</span>
-                            {% else %}
-                                <span class="reg-major-text">{{regulation.meta.statutory_name|title}}</span>
-                            {% endif %}
-                        </div>
-                        <span class="cf-icon cf-icon-right-round"></span>
-                    </a>
+        {% block regulations-title %}
+            <div class="regulations-title">
+            <h2>Regulations</h2>
+            <h2 class="small-header">
+                {% block cfr_title %}Title {{cfr_titleno_arabic}} {{cfr_title_text}}{% endblock %}
+            </h2>
+          </div>
+        {% endblock %}
 
-                    {% for amendment in regulation.amendments %}
-                        <div class="mini-alert important">
-                            New amendment effective {{amendment.by_date|date:'n/j/Y'}}
-                            <a href="{% url 'chrome_section_view' regulation.reg_first_section amendment.version %}" class="go">View new amendment</a>
-                        </div>
-                    {% endfor %}
-                </li>
-            {% endfor %}
-        </ul>
+        {% block reg-list %}
+        {{ block.super }}
+        {% endblock %}
 
         {% block moreregulations %}
         {% endblock %}


### PR DESCRIPTION
This PR overwrites the body block of generic_universal.html (the eregs landing page), in order to provide custom templating and styling, including a search pane which can be used to search all regulations.

SHOULD BE MERGED AFTER eregs/regulations-site#419