### PR TITLE
FEC style subhead

### DIFF
--- a/fec_eregs/static/fec_eregs/scss/_components.scss
+++ b/fec_eregs/static/fec_eregs/scss/_components.scss
@@ -12,6 +12,9 @@
   font-family: $serif;
 }
 
+// Override `ul`s in `.reg-header` styles
+// TODO remove element specific styles in regulations-site, replace
+// with class-based rules, e.g. `ul.eregs-list`.
 .reg-header .utility-nav {
   @extend .utility-nav;
 }
@@ -19,6 +22,10 @@
 .utility-nav__item {
   margin-top: 0;
   padding: 0 20px;
+}
+
+.reg-header .site-nav__panel {
+  @extend .site-nav__panel;
 }
 
 //TODO when the breakpoints are fixed, this shouldn't be necessary

--- a/fec_eregs/static/fec_eregs/scss/_components.scss
+++ b/fec_eregs/static/fec_eregs/scss/_components.scss
@@ -30,3 +30,8 @@
   @extend .disclaimer;
   width: calc(100% - 90px);
 }
+
+.breadcrumbs {
+  // Font-size from body
+  font-size: 14px;
+}

--- a/fec_eregs/static/fec_eregs/scss/main.scss
+++ b/fec_eregs/static/fec_eregs/scss/main.scss
@@ -31,6 +31,8 @@ $x-large-screen: 1100px;
 @import 'mixins/utilities';
 @import 'mixins/icon-mixins';
 
+@import 'layout/slabs';
+
 // Base styling for html elements
 @import 'elements/links';
 @import 'elements/lists';
@@ -38,11 +40,13 @@ $x-large-screen: 1100px;
 @import 'elements/tables';
 @import 'elements/images';
 
+@import 'components/breadcrumbs';
+@import 'components/buttons';
 @import 'components/form-styles';
 @import 'components/list-styles';
 @import 'components/mega-menu';
+@import 'components/page-headers';
 @import 'components/search-bar';
-@import 'components/buttons';
 
 @import 'modules/site-header';
 @import 'modules/nav';

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -93,7 +93,7 @@ a {
 @subhead-primary-border: 2px solid @primary;
 @subhead-secondary-border: 1px solid @primary;
 @subhead-tertiary-border: 1px solid @gray-medium;
-@subhead-background: @neutral;
+@subhead-background: @primary;
 @toc-border: 1px solid @neutral-contrast;
 @toc-background: @neutral;
 
@@ -110,19 +110,36 @@ a {
 
 .sub-head {
   background-color: @subhead-background;
-  border-bottom: @subhead-secondary-border;
-  color: @primary;
+  border-bottom: none;
+  color: @gray-lightest;
+  height: @subhead_height;
+  line-height: inherit;
 }
 
 
 // TOC header
+// TODO We're really pushing the limits here, our TOC is diverged
+// significantly from regulations-site and should probably be written
+// with completely fec-eregs specific styles.
 .toc-head {
   background-color: @toc-background;
-  border-bottom: @subhead-secondary-border;
+  border-bottom: none;
+  border-right: none;
+  position: fixed;
+  width: auto;
+  left: 188px;
+  top: @mainhead_height + @subhead_height;
+  height: auto;
+  z-index: 1;
 
   a.current,
   a:hover {
     background-color: @primary;
+  }
+
+  // Overrides for closed panel
+  .close & {
+    left: 0;
   }
 }
 
@@ -184,7 +201,7 @@ html, body, .landing-content, .search-panel {
   border-right: @subhead-primary-border;
 
   &.close {
-    top: @mainhead_height + @subhead_height + 2 * 34px + 1; // Header, subheader, 2 TOC list items + 1 drawer-toggles border
+    top: @mainhead_height + @subhead_height;
   }
 }
 
@@ -228,7 +245,7 @@ html, body, .landing-content, .search-panel {
   }
 }
 
-.drawer-header, .toc-head {
+.drawer-header {
   border-right: @subhead-primary-border;
 }
 
@@ -255,6 +272,16 @@ html, body, .landing-content, .search-panel {
 .regulation-nav .current {
   padding: 10px 5px;
   margin: 0 10px;
+}
+
+// Subhead
+#content-header {
+  padding-left: initial;
+
+  .header-label {
+    font-weight: inherit;
+    font-style: inherit;
+  }
 }
 
 

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -126,11 +126,12 @@ a {
   background-color: @toc-background;
   border-bottom: none;
   border-right: none;
-  position: fixed;
-  width: auto;
-  left: 188px;
-  top: @mainhead_height + @subhead_height;
   height: auto;
+  left: 188px;
+  position: fixed;
+  top: @mainhead_height + @subhead_height;
+  transition: none;
+  width: auto;
   z-index: 1;
 
   a.current,

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -139,7 +139,7 @@ a {
     background-color: @primary;
   }
 
-  #panel-link {
+  .panel-slide {
     width: 38px;
   }
 

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -105,7 +105,8 @@ a {
 }
 
 .main-head {
-  border-bottom: 3px solid @primary;
+  border-bottom: none;
+  height: @mainhead_height;
 }
 
 .sub-head {
@@ -137,8 +138,13 @@ a {
     background-color: @primary;
   }
 
+  #panel-link {
+    width: 38px;
+  }
+
   // Overrides for closed panel
   .close & {
+    height: auto;
     left: 0;
   }
 }
@@ -306,10 +312,6 @@ html, body, .landing-content, .search-panel {
 //
 .hero {
   width: 100%;
-}
-
-.main-head {
-  height: @mainhead_height;
 }
 
 .landing-content,

--- a/fec_eregs/static/regulations/css/less/variables.less
+++ b/fec_eregs/static/regulations/css/less/variables.less
@@ -78,5 +78,5 @@ variables.less contains all theme variable / variable overrides
 
 @body_font: @base-font-family;
 
-@mainhead_height: 116px;
-@subhead_height: 57px;
+@mainhead_height: 173px;
+@subhead_height: 0px;

--- a/fec_eregs/static/regulations/css/less/variables.less
+++ b/fec_eregs/static/regulations/css/less/variables.less
@@ -79,4 +79,4 @@ variables.less contains all theme variable / variable overrides
 @body_font: @base-font-family;
 
 @mainhead_height: 116px;
-@subhead_height: 34px;
+@subhead_height: 57px;

--- a/fec_eregs/templates/regulations/chrome.html
+++ b/fec_eregs/templates/regulations/chrome.html
@@ -1,13 +1,45 @@
 {% overextends "regulations/chrome.html" %}
 {% load static from staticfiles %}
 
-{% block sidebar-drawer-icons %}
-<a href="#" id="panel-link" class="toc-toggle panel-slide">
-  <img id="open-active" src="{%static "regulations/img/open-caret.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
-  <img id="open" src="{%static "regulations/img/open-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
-  <img id="close" src="{%static "regulations/img/close-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
-  <img id="close-active" src="{%static "regulations/img/close-caret.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
-</a>
+{% block sub-head-drawer-icons %}
+{% endblock %}
+
+{% block sub-head-content %}
+<div class="page-header">
+  <ul class="breadcrumbs">
+    <li class="breadcrumbs__item">
+      <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/">Home</a>
+    </li>
+    <li class="breadcrumbs__item">
+      <span class="breadcrumbs__separator">&gt;</span>
+      <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/legal-resources/">Legal resources</a>
+    </li>
+    <li class="breadcrumbs__item">
+      <span class="breadcrumbs__separator">&gt;</span>
+      <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/legal/regulations/">Regulations</a>
+    </li>
+    <li id="content-header" class="breadcrumbs__item breadcrumbs__item--current">
+      <span class="breadcrumbs__separator">&gt;</span>
+      {% block wayfinding %}
+      {{ block.super }}
+      {% endblock %}
+    </li>
+  </ul>
+</div>
+{% endblock %}
+
+{% block drawer-toc %}
+<a href="#content-wrapper" class="hidden-text">Skip to main content</a> <!-- skip to content link for screen readers-->
+<div class="toc-head">
+  <a href="#" id="panel-link" class="toc-toggle panel-slide">
+    <img id="open-active" src="{%static "regulations/img/open-caret.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
+    <img id="open" src="{%static "regulations/img/open-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
+    <img id="close" src="{%static "regulations/img/close-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
+    <img id="close-active" src="{%static "regulations/img/close-caret.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
+  </a>
+</div> <!-- /toc-head-->
+
+{{ block.super }}
 {% endblock %}
 
 {% block sidebar-toc-link %}
@@ -17,9 +49,6 @@
 {% endblock %}
 
 {% block sidebar-search-link %}
-{% endblock %}
-
-{% block header-secondary %}
 {% endblock %}
 
 {% block drawer-search %}

--- a/fec_eregs/templates/regulations/chrome.html
+++ b/fec_eregs/templates/regulations/chrome.html
@@ -5,11 +5,11 @@
 {% comment %}
 Empty the sub-head, we use the breadcrumbs in main-header.html
 {% endcomment %}
+{% block sub-head-skip-nav %}{% endblock %}
 {% block sub-head-drawer-icons %}{% endblock %}
 {% block sub-head-content %}{% endblock %}
 
 {% block drawer-toc %}
-<a href="#content-wrapper" class="hidden-text">Skip to main content</a> <!-- skip to content link for screen readers-->
 <div class="toc-head">
   <a href="#" id="panel-link" class="toc-toggle panel-slide">
     <img id="open-active" src="{%static "regulations/img/open-caret.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />

--- a/fec_eregs/templates/regulations/chrome.html
+++ b/fec_eregs/templates/regulations/chrome.html
@@ -1,32 +1,12 @@
 {% overextends "regulations/chrome.html" %}
 {% load static from staticfiles %}
 
-{% block sub-head-drawer-icons %}
-{% endblock %}
 
-{% block sub-head-content %}
-<div class="page-header">
-  <ul class="breadcrumbs">
-    <li class="breadcrumbs__item">
-      <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/">Home</a>
-    </li>
-    <li class="breadcrumbs__item">
-      <span class="breadcrumbs__separator">&gt;</span>
-      <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/legal-resources/">Legal resources</a>
-    </li>
-    <li class="breadcrumbs__item">
-      <span class="breadcrumbs__separator">&gt;</span>
-      <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/legal/regulations/">Regulations</a>
-    </li>
-    <li id="content-header" class="breadcrumbs__item breadcrumbs__item--current">
-      <span class="breadcrumbs__separator">&gt;</span>
-      {% block wayfinding %}
-      {{ block.super }}
-      {% endblock %}
-    </li>
-  </ul>
-</div>
-{% endblock %}
+{% comment %}
+Empty the sub-head, we use the breadcrumbs in main-header.html
+{% endcomment %}
+{% block sub-head-drawer-icons %}{% endblock %}
+{% block sub-head-content %}{% endblock %}
 
 {% block drawer-toc %}
 <a href="#content-wrapper" class="hidden-text">Skip to main content</a> <!-- skip to content link for screen readers-->

--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -53,7 +53,7 @@
       </li>
       <li class="breadcrumbs__item">
         <span class="breadcrumbs__separator">&gt;</span>
-        <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/legal/regulations/">Regulations</a>
+        <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/regulations/">Regulations</a>
       </li>
       {% if reg_part %}
       <li id="content-header" class="breadcrumbs__item breadcrumbs__item--current">

--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -42,4 +42,28 @@
     <button for="nav-toggle" class="js-nav-toggle site-nav__button site-nav__button--left" aria-controls="site-menu">Menu</button>
     <a title="Home" href="{{ FEC_CMS_URL }}/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
   </nav>
+  <div class="page-header page-header--primary">
+    <ul class="breadcrumbs">
+      <li class="breadcrumbs__item">
+        <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/">Home</a>
+      </li>
+      <li class="breadcrumbs__item">
+        <span class="breadcrumbs__separator">&gt;</span>
+        <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/legal-resources/">Legal resources</a>
+      </li>
+      <li class="breadcrumbs__item">
+        <span class="breadcrumbs__separator">&gt;</span>
+        <a class="breadcrumbs__link" href="{{ FEC_CMS_URL }}/legal/regulations/">Regulations</a>
+      </li>
+      {% if reg_part %}
+      <li id="content-header" class="breadcrumbs__item breadcrumbs__item--current">
+        <span class="breadcrumbs__separator">&gt;</span>
+        <span class="wayfinding">
+          <span class="subpart"></span>
+          <span id="active-title">{% block active_title %}<em class="header-label"><span class="reg_part">§{{ reg_part }}</span></em>{% endblock %}</span>
+        </span>
+      </li>
+      {% endif %}
+    </ul>
+  </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "eRegulations viewer for the Federal Election Commission's public legal resources.",
   "dependencies": {
-    "fec-style": "^2.2.0"
+    "fec-style": "^2.5.1"
   },
   "devDependencies": {
     "browserify": "^13.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ jsonschema==2.5.1
 # django already covered
 lxml==3.5.0
 requests==2.8.1
--e git+https://github.com/18F/regulations-site.git@1f6ed14eee9a01ddfbf289ddef463f388bc58e59#egg=regulations
+-e git+https://github.com/18F/regulations-site.git@1906b362ab648213f6ffe3439acb8dcf1ad63ded#egg=regulations
 
 # fec-specific/cloud.gov
 cfenv==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ jsonschema==2.5.1
 # django already covered
 lxml==3.5.0
 requests==2.8.1
--e git+https://github.com/18F/regulations-site.git@1906b362ab648213f6ffe3439acb8dcf1ad63ded#egg=regulations
+-e git+https://github.com/18F/regulations-site.git@6a8fe95337f4f50c2f2e2c2aec1ceb86b192a276#egg=regulations
 
 # fec-specific/cloud.gov
 cfenv==0.5.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ coveralls
 pep8==1.5.7
 lxml
 nose-exclude
-
+httpretty


### PR DESCRIPTION
Resolves https://github.com/18F/fec-eregs/issues/115

- Moves the drawer toggle to inside the panel
- Many style overrides to work with the existing drawer toggle

- [x] wayfinder offset looks off (top paragraph is not the one labeled in the sub-head).
- [x] depends on https://github.com/eregs/regulations-site/pull/418.
- [x] missing sub-head on main landing page.
- [x] breadcrumb link should link to `/regulations`.