### PR TITLE
Disable collectstatic at runtime

### DIFF
--- a/fec_eregs/settings/base.py
+++ b/fec_eregs/settings/base.py
@@ -12,6 +12,7 @@ from regulations.settings.base import *
 REGSITE_APPS = tuple(INSTALLED_APPS)
 
 INSTALLED_APPS = ('overextends', 'fec_eregs',) + REGCORE_APPS + REGSITE_APPS
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 NOSE_ARGS = [
     '--with-coverage',
@@ -34,6 +35,7 @@ API_BASE = 'http://localhost:{}/api/'.format(
     os.environ.get('VCAP_APP_PORT', '8000'))
 
 STATICFILES_DIRS = ['compiled']
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 DATA_LAYERS = DATA_LAYERS or []
 

--- a/manifest.base.yml
+++ b/manifest.base.yml
@@ -1,6 +1,6 @@
 ---
 buildpack: python_buildpack
-command: python manage.py migrate --fake-initial && python manage.py collectstatic --noinput && waitress-serve --url-prefix /regulations --port=$VCAP_APP_PORT fec_eregs.wsgi:application
+command: python manage.py migrate --fake-initial && waitress-serve --url-prefix /regulations --port=$VCAP_APP_PORT fec_eregs.wsgi:application
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
   - fec-eregs-db


### PR DESCRIPTION
`regulations-site` doesn't set `STATIC_ROOT`, so `collectstatic` fails at
buildpack time. This sets `STATIC_ROOT`, so it works.

Also disables `collectstatic` at runtime, which is redundant.