### PR TITLE
Bug/mobile header white space

### DIFF
--- a/fec_eregs/static/fec_eregs/scss/_components.scss
+++ b/fec_eregs/static/fec_eregs/scss/_components.scss
@@ -52,9 +52,12 @@
 
 .fec-disclaimer {
   @extend .disclaimer;
-  width: calc(100% - 90px);
   // We need to keep the header height fixed, don't wrap on small screens
-  @include u-truncate()
+  @include u-truncate();
+
+  @include media($med) {
+    width: calc(100% - 90px);
+  }
 }
 
 .breadcrumbs {

--- a/fec_eregs/static/fec_eregs/scss/_components.scss
+++ b/fec_eregs/static/fec_eregs/scss/_components.scss
@@ -25,10 +25,14 @@
 
 .site-nav {
   position: relative;
+
+  .site-title {
+    width: calc(100% - 150px);
+  }
 }
 
 .site-nav__container {
-  @media(max-width: 720px) {
+  @include media(max-width ($large-screen - 1)) {
     bottom: initial;
     top: 40px;
     z-index: initial;
@@ -49,6 +53,8 @@
 .fec-disclaimer {
   @extend .disclaimer;
   width: calc(100% - 90px);
+  // We need to keep the header height fixed, don't wrap on small screens
+  @include u-truncate()
 }
 
 .breadcrumbs {

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -348,4 +348,22 @@ html, body, .landing-content, .search-panel {
   .toc-head {
     top: @mainhead_small_height;
   }
+
+  // Offsets for making the url fragments line-up the section content correctly
+  // See layouts.less in regulations-site
+  .reg-section:before,
+  .appendix-section:before,
+  .supplement-section:before,
+  .supplement-section section:before,
+  .footnotes li:before {
+      height: @mainhead_small_height;
+      margin: -1 * @mainhead_small_height 0 0;
+  }
+
+  .reg-section .level-1 li,
+  .appendix-section .level-1 li,
+  .supplement-section .level-1 li {
+      border-top: @mainhead_small_height solid transparent;
+      margin-top: -1 * @mainhead_small_height;
+  }
 }

--- a/fec_eregs/static/regulations/css/less/module/custom.less
+++ b/fec_eregs/static/regulations/css/less/module/custom.less
@@ -1,4 +1,9 @@
 /**
+ * Variables
+ */
+@mainhead_small_height: 83px; // main-head height on small devices
+
+/**
  * Font mixin overrides
  *
  * These are used within the regulations-site less.
@@ -323,5 +328,24 @@ html, body, .landing-content, .search-panel {
     display: table;
     height: auto;
     margin-top: 0;
+  }
+}
+
+@media only screen and ( max-width: 719px ) {
+  .main-head,
+  .reg-header {
+    height: @mainhead_small_height;
+  }
+
+  .landing-content,
+  .main-content,
+  .about-content {
+    margin-top: @mainhead_small_height;
+  }
+
+  .panel,
+  .panel.close,
+  .toc-head {
+    top: @mainhead_small_height;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/18F/fec-eregs/issues/116

The collapsed primary-blue `.page-header` is from `fec-style`. Unfortunately it means our wayfinder is not visible in mobile. Not sure if @edmullen was intending for this to be a custom component, but I think fixing this is tied to https://github.com/18F/fec-eregs/issues/124.

![screenshot from 2016-06-23 17-44-33](https://cloud.githubusercontent.com/assets/509703/16324544/30a464c2-396a-11e6-8be4-8b485d6ecd86.png)
