### PR TITLE
Fix mega-menu links

### DIFF
--- a/fec_eregs/static/fec_eregs/js/fec.js
+++ b/fec_eregs/static/fec_eregs/js/fec.js
@@ -12,6 +12,9 @@ helpers.BREAKPOINTS.LARGE = 720;
 var $ = window.$;
 $(function () {
   $('.js-site-nav').each(function () {
-    new SiteNav(this);
+    new SiteNav(this, {
+      cmsUrl: window.CMS_URL,
+      webAppUrl: window.WEB_URL
+    });
   });
 });

--- a/fec_eregs/templates/regulations/base.html
+++ b/fec_eregs/templates/regulations/base.html
@@ -8,6 +8,7 @@ window.API_VERSION = "{{ FEC_API_VERSION }}";
 window.API_KEY = "{{ FEC_API_KEY }}";
 window.API_LOCATION = "{{ FEC_API_URL }}";
 window.CMS_URL = "{{ FEC_CMS_URL }}";
+window.WEB_URL = "{{ FEC_WEB_URL }}";
 </script>
 <script type="text/javascript" src="{% static "fec_eregs/js/fec.bundle.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
You can see on https://fec-stage-proxy.18f.gov/regulations/ that the mega menu links aren't working (pointing to the default `localhost`). Initialize the `SiteNav` so we're not using dev defaults.