### PR TITLE
require Django 1.8.14 instead of 1.8.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # regulations-core
 anyjson==0.3.3
-django==1.8.13
+django==1.8.14
 django-haystack==2.4.1
 jsonschema==2.5.1
 -e git+https://github.com/18F/regulations-core.git#egg=regcore


### PR DESCRIPTION
Django 1.8.14 patches a security vulnerability discovered in 18.13. The vulnerability doesn't affect us at present, but better to patch now so we don't have to remember later. I've run the update locally and all tests pass.