### PR TITLE
[merge with git flow] Bump django for CVE-2016-7401

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # regulations-core
 anyjson==0.3.3
-django==1.8.14
+django==1.8.15
 django-haystack==2.4.1
 jsonschema==2.5.1
 -e git+https://github.com/18F/regulations-core.git@2.0.0#egg=regcore


### PR DESCRIPTION
https://www.djangoproject.com/weblog/2016/sep/26/security-releases/