### PR TITLE
Restore left chevron in footer-nav

### DIFF
--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -375,12 +375,7 @@ html, body, .landing-content, .search-panel {
   }
 }
 
-// Footer
-.footer-nav {
-  overflow: hidden;
-  margin-bottom: 50px;
-}
-
 div.footer-disclaimer {
+  margin-left: -15px;
   padding: 14px 30px 14px 30px;
 }


### PR DESCRIPTION
Also, make the footer-disclaimer align with the footer-nav.

Fixes 18F/fec-eregs#261