### PR TITLE
Adds missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ whitenoise==3.0
 newrelic==2.74.0.54
 
 -e eregs_extensions/
+
+functools32==3.2.3-2


### PR DESCRIPTION
I got this up and running for the first time, but found I was missing the `functools` dependency. Let me know if this shouldn't be in requirements.txt or if it should be a different version or something.