### PR TITLE
Updating nav, cleaning up styles, fixing bugs

### DIFF
--- a/fec_eregs/static/fec_eregs/scss/_headings.scss
+++ b/fec_eregs/static/fec_eregs/scss/_headings.scss
@@ -10,7 +10,7 @@
 @import 'variables';
 
 h1,h2,h3,h4,h5,h6 {
-  color: $primary;
+  color: $base;
 }
 
 h1 {

--- a/fec_eregs/static/regulations/css/scss/_typography.scss
+++ b/fec_eregs/static/regulations/css/scss/_typography.scss
@@ -14,7 +14,7 @@ typography.scss contains both global and application specific typography */
 */
 
 body {
-    color: $primary;
+    color: $base;
     font-family: $body_font;
     font-size: 1em;
     /*line-height: 1.625;*/ /* 26px */

--- a/fec_eregs/static/regulations/css/scss/_variables.scss
+++ b/fec_eregs/static/regulations/css/scss/_variables.scss
@@ -16,7 +16,7 @@ $base-font-family: $serif;
 // Primary colors
 $crimson: #631010;
 $orange: #f77b42;
-$federal-blue: #022c53;
+$federal-blue: #112e51;
 $aqua: #36bdbb;
 
 $base: #212121;

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -3,6 +3,14 @@
  */
 $mainhead_small_height: 83px; // main-head height on small devices
 
+// Clearfixing the section nav at the bottom
+.section-nav {
+  &::after {
+    content: '';
+    display: table;
+  }
+}
+
 /**
  * Font mixin overrides
  *

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -204,7 +204,7 @@ html, body, .landing-content, .search-panel {
 }
 
 .regulations-title {
-  border-bottom: 2px solid #112e51;
+  border-bottom: 2px solid $primary;
   padding-bottom: 10px;
 }
 
@@ -219,7 +219,7 @@ html, body, .landing-content, .search-panel {
 // TOC
 .panel {
   background-color: $toc-background;
-  border-right: $subhead-primary-border;
+  border-right: 1px solid $primary;
 
   &.close {
     top: $mainhead_height + $subhead_height;
@@ -267,14 +267,14 @@ html, body, .landing-content, .search-panel {
 }
 
 .drawer-header {
-  border-right: $subhead-primary-border;
+  border-right: 1px solid $primary;
 }
 
 .drawer-header .toc-type {
-  @include serif-font-regular;
+  @include sans-font-regular;
   background-color: $toc-background;
-  border-bottom: $toc-border;
-  color: $primary;
+  border-right-width: 0;
+  color: $base;
   font-weight: 700;
 }
 
@@ -286,7 +286,6 @@ html, body, .landing-content, .search-panel {
 
 .regulation-nav a:link, .regulation-nav a:visited {
   border-bottom: $toc-border;
-  color: $primary;
 }
 
 // FEC is less boxy

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -5,10 +5,20 @@ $mainhead_small_height: 83px; // main-head height on small devices
 
 // Clearfixing the section nav at the bottom
 .section-nav {
-  &::after {
+  &::before {
     content: '';
     display: table;
   }
+
+  &::after {
+    content: '';
+    display: table;
+    clear: both;
+  }
+}
+
+.footer-nav {
+  margin-bottom: 20px;
 }
 
 /**
@@ -378,6 +388,8 @@ html, body, .landing-content, .search-panel {
 }
 
 div.footer-disclaimer {
+  border: 1px solid $gray-medium;
+  font-family: $sans-serif;
   margin-left: -15px;
   padding: 14px 30px 14px 30px;
 }

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -389,7 +389,10 @@ html, body, .landing-content, .search-panel {
 
 div.footer-disclaimer {
   border: 1px solid $gray-medium;
-  font-family: $sans-serif;
   margin-left: -15px;
   padding: 14px 30px 14px 30px;
+
+  p {
+    font-family: $sans-serif;
+  }
 }

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -201,10 +201,6 @@ html, body, .landing-content, .search-panel {
 .search-header {
   border-bottom: 2px solid $gray;
   margin-bottom: 2rem;
-  padding: .5rem;
-  font-size: 1.5rem;
-  font-family: ghandi, serif;
-  text-align: center;
 }
 
 .regulations-title {

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -267,13 +267,12 @@ html, body, .landing-content, .search-panel {
 }
 
 .drawer-header {
-  border-right: 1px solid $primary;
+  border-right: none !important;
 }
 
 .drawer-header .toc-type {
   @include sans-font-regular;
   background-color: $toc-background;
-  border-right-width: 0;
   color: $base;
   font-weight: 700;
 }

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -11,17 +11,18 @@
 <div class="usa-width-one-fourth search-panel">
     <div class="container">
       <div class="u-padding-left u-padding--right">
-          <div class="search-header">Search regulations</div>
-          <form action="{{ FEC_WEB_URL }}/legal/search/regulations/" method="GET" role="search">
+          <h2 class="search-header">Search regulations</h2>
+          <form action="{{ FEC_WEB_URL }}/legal/search/regulations/" method="GET" role="search" class="group">
             <div class="combo--search--mini">
-              <label class="label t-left-aligned" for="search-regs">Terms</label>
+              <label class="label t-left-aligned" for="search-regs">Keywords</label>
               <input id="search-regs" name="search" class="combo__input" type="text" title="Search term"/>
               <input type="hidden" name="search_type" id="version-hidden" title="Search Type" value="regulations"/>
               <button class="combo__button button--search button--standard" type="submit"/>
                 <span class="u-visually-hidden">Search</span></button>
             </div>
           </form>
-        </div>
+          <p class="t-note t-sans search__example">Examples: spending; 9003.6</p>
+      </div>
     </div>
 </div>
 <div class="usa-width-three-fourths" role="main">

--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -10,8 +10,7 @@
   <div class="masthead">
     <a href="{{ FEC_CMS_URL }}/" title="Home" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
     <ul class="utility-nav list--flat">
-      <li class="utility-nav__item is-disabled">(About)</li>
-      <li class="utility-nav__item"><a href="{{ FEC_CMS_URL }}/contact-us/">Contact</a></li>
+      <li class="utility-nav__item is-disabled">About</li>
       <li class="utility-nav__item"><a href="{{ FEC_CMS_URL }}/calendar/">Calendar</a></li>
       <li class="utility-nav__item is-disabled"><span class="js-glossary-toggle glossary__toggle">Glossary</span></li>
     </ul>
@@ -29,10 +28,7 @@
           <a href="{{ FEC_CMS_URL }}/legal-resources/" class="site-nav__link is-parent">Legal resources</a>
         </li>
         <li class="site-nav__item utility-nav__item is-disabled">
-          <a href="#" class="site-nav__link">(About)</a>
-        </li>
-        <li class="site-nav__item utility-nav__item">
-          <a href="{{ FEC_CMS_URL }}/contact-us/" class="site-nav__link">Contact</a>
+          <a href="#" class="site-nav__link">About</a>
         </li>
         <li class="site-nav__item utility-nav__item">
           <a href="{{ FEC_CMS_URL }}/calendar/" class="site-nav__link">Calendar</a>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "eRegulations viewer for the Federal Election Commission's public legal resources.",
   "dependencies": {
-    "fec-style": "^2.5.1"
+    "fec-style": "5.8.2"
   },
   "devDependencies": {
     "browserify": "^13.0.1",


### PR DESCRIPTION
This started as me getting eregs running locally so I could update the nav, but then ended up rabbit-holing and fixing a few other things. So here's what this does:

1. Removes "Contact" from utility nav and the parentheses around "About" ([issue](https://github.com/18F/openFEC-web-app/issues/1714))
![image](https://cloud.githubusercontent.com/assets/1696495/20781016/911a989c-b734-11e6-9137-bf5dbd810d87.png)

2. Fixes the issue where the next / previous links would overflow. This was caused by their container not clearing their floats. Resolves https://github.com/18F/fec-eregs/issues/315

![image](https://cloud.githubusercontent.com/assets/1696495/20781031/a745003a-b734-11e6-901b-ef6436c6fa67.png)

3. It bumps up the version of fec-style to the current version. I took a look through and everything seems to be in order, but a second set of eyes wouldn't hurt to make sure nothing broke.

4. With fec-style updated, I implemented the changes from https://github.com/18F/fec-eregs/pull/302/ : adding an example below the search box, and improved styling of the heading here.

![image](https://cloud.githubusercontent.com/assets/1696495/20781112/2bb3dfd0-b735-11e6-81fa-3714dd44c6d0.png)

5. I made some general style clean-up: I set the default font color to the `$base` value we use elsewhere on the site, and made the borders on the table of contents 1px for consistency:

![image](https://cloud.githubusercontent.com/assets/1696495/20781153/70d764a6-b735-11e6-9312-8a81bd2e2fd9.png)

I also replaced the previous serif title there with sans-serif, as it's set in all caps and I thought it looked better. Current version: 

![image](https://cloud.githubusercontent.com/assets/1696495/20781161/8e6f99d4-b735-11e6-93ff-38cfea513fcb.png)

cc @jenniferthibault 

Now that I'm getting familiar with this I know there's a lot we can do to clean things up visually, but I also know that it's not a priority, so I wanna keep things to these fixes for now. 
  