### PR TITLE
Add credentials services to manifest.stage.yml and manifest.prod.yml.

### DIFF
--- a/manifest.base.yml
+++ b/manifest.base.yml
@@ -2,7 +2,7 @@
 buildpack: python_buildpack
 command: python manage.py migrate --fake-initial && gunicorn --bind=0.0.0.0:$PORT fec_eregs.wsgi:application
 services:
-  - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD, NEW_RELIC_LICENSE_KEY
+  - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
   - fec-eregs-db
   - fec-eregs-search-1.7.1
 env:

--- a/manifest.prod.yml
+++ b/manifest.prod.yml
@@ -7,3 +7,5 @@ env:
   FEC_CMS_URL: https://beta.fec.gov
   FEC_WEB_URL: https://beta.fec.gov/data
   NEW_RELIC_APP_NAME: fec-prod-eregs
+services:
+    - fec-creds-prod

--- a/manifest.stage.yml
+++ b/manifest.stage.yml
@@ -6,3 +6,5 @@ env:
   FEC_CMS_URL: https://fec-stage-proxy.18f.gov
   FEC_WEB_URL: https://fec-stage-proxy.18f.gov/data
   NEW_RELIC_APP_NAME: fec-stage-eregs
+services:
+    - fec-creds-stage


### PR DESCRIPTION
This should get New Relic reporting going for eRegs on `stage` and `prod`.