### PR TITLE
Feature/remove beta language

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ flow](https://danielkummer.github.io/git-flow-cheatsheet/).
 
 Environment | URL                              | Proxy | Description
 ----------- | ---                              | ----- | -----------
-`dev`       | https://fec-dev-eregs.18f.gov/   | https://fec-dev-proxy.18f.gov/regulations/ | Ad-hoc testing, deploys the latest changes from `develop`.
-`stage`     | https://fec-stage-eregs.18f.gov/ | https://fec-stage-proxy.18f.gov/regulations/ | Staging site, deployed from branches matching `release/*`.
-`prod`      | https://fec-prod-eregs.18f.gov/  | https://beta.fec.gov/regulations/ | Production site, deployed from any tagged commit.
+`dev`       | https://fec-dev-eregs.app.cloud.gov/   | https://fec-dev-proxy.app.cloud.gov/regulations/ | Ad-hoc testing, deploys the latest changes from `develop`.
+`stage`     | https://fec-stage-eregs.app.cloud.gov/ | https://fec-stage-proxy.app.cloud.gov/regulations/ | Staging site, deployed from branches matching `release/*`.
+`prod`      | https://fec-prod-eregs.app.cloud.gov/  | https://beta.fec.gov/regulations/ | Production site, deployed from any tagged commit.
 
 
 ### Travis

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use pip and npm to download the required libraries:
 ```bash
 $ pip install -r requirements.txt
 $ pip install -r requirements_dev.txt
-$ npm install 
+$ npm install
 $ npm install -g grunt-cli bower
 ```
 
@@ -50,7 +50,7 @@ If you aren't working on the parser, you may want to just configure the
 application to run against the live API:
 
 ```bash
-$ echo "API_BASE = 'https://fec-prod-eregs.18f.gov/regulations/api/'" >> local_settings.py
+$ echo "API_BASE = 'https://fec-prod-eregs.app.cloud.gov/regulations/api'" >> local_settings.py
 ```
 
 ### Ports

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you aren't working on the parser, you may want to just configure the
 application to run against the live API:
 
 ```bash
-$ echo "API_BASE = 'https://fec-prod-eregs.app.cloud.gov/regulations/api'" >> local_settings.py
+$ echo "API_BASE = 'https://fec-prod-eregs.app.cloud.gov/regulations/api/'" >> local_settings.py
 ```
 
 ### Ports

--- a/fec_eregs/static/fec_eregs/scss/_components.scss
+++ b/fec_eregs/static/fec_eregs/scss/_components.scss
@@ -64,3 +64,8 @@
   // Font-size from body
   font-size: 14px;
 }
+
+input[type="text"].combo__input {
+  border: 2px solid $gray;
+  text-align: left;
+}

--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -12,6 +12,24 @@
     <ul class="utility-nav list--flat">
       <li class="utility-nav__item"><a href="{{ FEC_CMS_URL }}/calendar/">Calendar</a></li>
       <li class="utility-nav__item is-disabled"><span class="js-glossary-toggle glossary__toggle">Glossary</span></li>
+      <li class="utility-nav__search">
+        <form accept-charset="UTF-8" action="{{ FEC_CMS_URL }}/search" class="combo" method="get" role="search">
+          <input type="hidden" name="type" value="candidates">
+          <input type="hidden" name="type" value="committees">
+          <input type="hidden" name="type" value="site">
+          <label class="u-visually-hidden" for="query">Search</label>
+          <input
+            class="js-site-search combo__input"
+            autocomplete="off"
+            id="query"
+            name="query"
+            type="text"
+            aria-label="Search FEC.gov">
+          <button type="submit" class="button--standard combo__button button--search">
+            <span class="u-visually-hidden">Search</span>
+          </button>
+        </form>
+      </li>
     </ul>
   </div>
   <nav class="site-nav js-site-nav">
@@ -41,6 +59,24 @@
         <li class="site-nav__item utility-nav__item u-under-lg-only">
           <a href="{{ FEC_CMS_URL }}/calendar" class="site-nav__link">Calendar</a>
         </li>
+        <li class="site-nav__item site-nav__link utility-nav__item u-under-lg-only">
+          <form accept-charset="UTF-8" action="{{ cms_url }}/search" class="combo combo--search--mini" method="get" role="search">
+            <input type="hidden" name="type" value="candidates">
+            <input type="hidden" name="type" value="committees">
+            <input type="hidden" name="type" value="site">
+            <label class="u-visually-hidden" for="mobile-search">Search</label>
+            <input
+              class="js-site-search combo__input"
+              autocomplete="off"
+              id="mobile-search"
+              name="query"
+              type="text"
+              aria-label="Search FEC.gov">
+            <button type="submit" class="button--standard combo__button button--search">
+              <span class="u-visually-hidden">Search</span>
+            </button>
+          </form>
+        </li>        
       </ul>
     </div>
     <button for="nav-toggle" class="js-nav-toggle site-nav__button" aria-controls="site-menu">Menu</button>

--- a/fec_eregs/templates/regulations/regulation-content.html
+++ b/fec_eregs/templates/regulations/regulation-content.html
@@ -7,17 +7,9 @@
         {%include "regulations/navigation.html"%}
     {% endfor %}
     <div class="slab slab--neutral footer-disclaimer">
-            <p>
-              <small>This site is in beta, which means we're testing content. This content is not finalized,
-              is not legal advice and is subject to change.
-              </small>
-            </p>
-            <p>
-              <small>Everything on this site should be read in conjunction with FEC.gov.
-              Please let us know what you think of our new content; use the feedback tool on the
-              <a href="https://beta.fec.gov/legal-resources/">legal resources</a> landing page.
-              </small>
-            </p>
-    </div>
-{% endif %}
+      <div class="container">
+          <p class="usa-width-one-half">This information is not intended to replace the law or to change its meaning, nor does this information create or confer any rights for or on any person or bind the Federal Election Commission or the public.</p>
+          <p class="usa-width-one-half">The reader is encouraged also to consult the Federal Election Campaign Act of 1971, as amended (52 U.S.C. 30101 et seq.), Commission regulations (Title 11 of the Code of Federal Regulations), Commission advisory opinions and applicable court decisions.</p>
+      </div>
+    </div>{% endif %}
 </section> <!-- /.reg-text -->

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "eRegulations viewer for the Federal Election Commission's public legal resources.",
   "dependencies": {
-    "fec-style": "11.1.1"
+    "fec-style": "11.2.0"
   },
   "devDependencies": {
     "browserify": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "eRegulations viewer for the Federal Election Commission's public legal resources.",
   "dependencies": {
-    "fec-style": "8.1.0"
+    "fec-style": "11.1.1"
   },
   "devDependencies": {
     "browserify": "^13.0.1",


### PR DESCRIPTION
This does a little cleanup in prep for launch:

This removes the beta disclaimer in favor of the standard disclaimer language we use elsewhere:
![image](https://cloud.githubusercontent.com/assets/1696495/26332718/6d1a9fc6-3f0d-11e7-97d5-cc7eaeda62ee.png)

And it adds the search bar to the header:
![image](https://cloud.githubusercontent.com/assets/1696495/26333094/f3174f6e-3f0f-11e7-852b-1d9d8e5f5c73.png)

And it updates the README references to apps / API.
