### PR TITLE
[MERGE WITH GIT FLOW] Remove beta message from banner

### DIFF
--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -1,7 +1,6 @@
 {% load static from staticfiles %}
 <div class="main-head">
   <div class="fec-disclaimer">
-    <span class="disclaimer__left">This site is in <a href="https://18f.gsa.gov/dashboard/stages/#beta">beta</a>, visit <a href="http://www.fec.gov">FEC.gov</a></span>
     <span class="disclaimer__right">
       An official website of the United States Government
       <img alt="US flag signifying that this is a United States Federal Government website" src="{% static "fec_eregs/img/us_flag_small.png" %}">
@@ -76,7 +75,7 @@
               <span class="u-visually-hidden">Search</span>
             </button>
           </form>
-        </li>        
+        </li>
       </ul>
     </div>
     <button for="nav-toggle" class="js-nav-toggle site-nav__button" aria-controls="site-menu">Menu</button>


### PR DESCRIPTION
**MERGE WITH GIT FLOW**

This changeset removes the beta message from the banner at the top.