### PR TITLE
Fix breadcrumbs

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -3,7 +3,7 @@ inherit: manifest_base.yml
 host: fec-dev-eregs
 env:
   FEC_API_URL: https://fec-dev-api.app.cloud.gov
-  FEC_CMS_URL: "/"
+  FEC_CMS_URL: "http://fec-dev-proxy.app.cloud.gov"
   FEC_WEB_URL: "/data"
   NEW_RELIC_APP_NAME: fec | dev | eregs
 services:

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -3,7 +3,7 @@ inherit: manifest_base.yml
 host: fec-dev-eregs
 env:
   FEC_API_URL: https://fec-dev-api.app.cloud.gov
-  FEC_CMS_URL: "http://fec-dev-proxy.app.cloud.gov"
+  FEC_CMS_URL: "https://fec-dev-proxy.app.cloud.gov"
   FEC_WEB_URL: "/data"
   NEW_RELIC_APP_NAME: fec | dev | eregs
 services:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -4,7 +4,7 @@ host: fec-prod-eregs
 instances: 4
 env:
   FEC_API_URL: https://fec-prod-api.18f.gov
-  FEC_CMS_URL: ""
+  FEC_CMS_URL: "http://www.fec.gov"
   FEC_WEB_URL: "/data"
   NEW_RELIC_APP_NAME: fec-prod-eregs
 services:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -4,7 +4,7 @@ host: fec-prod-eregs
 instances: 4
 env:
   FEC_API_URL: https://fec-prod-api.18f.gov
-  FEC_CMS_URL: "http://www.fec.gov"
+  FEC_CMS_URL: "https://www.fec.gov"
   FEC_WEB_URL: "/data"
   NEW_RELIC_APP_NAME: fec-prod-eregs
 services:

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -3,7 +3,7 @@ inherit: manifest_base.yml
 host: fec-stage-eregs
 env:
   FEC_API_URL: https://fec-stage-api.18f.gov
-  FEC_CMS_URL: ""
+  FEC_CMS_URL: "http://fec-stage-proxy.app.cloud.gov"
   FEC_WEB_URL: "/data"
   NEW_RELIC_APP_NAME: fec-stage-eregs
 services:

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -3,7 +3,7 @@ inherit: manifest_base.yml
 host: fec-stage-eregs
 env:
   FEC_API_URL: https://fec-stage-api.18f.gov
-  FEC_CMS_URL: "http://fec-stage-proxy.app.cloud.gov"
+  FEC_CMS_URL: "https://fec-stage-proxy.app.cloud.gov"
   FEC_WEB_URL: "/data"
   NEW_RELIC_APP_NAME: fec-stage-eregs
 services:


### PR DESCRIPTION
## Summary (required)

- Addresses https://github.com/18F/fec-eregs/issues/376
Breadcrumbs are currently broken in dev due to incorrectly set FEC_CMS_URL variable in the manifests. This PR should set those correctly per environment